### PR TITLE
fix(codegen): resolve date format mismatch for timestamp fields

### DIFF
--- a/openapi-ts.config.ts
+++ b/openapi-ts.config.ts
@@ -7,6 +7,18 @@ export default defineConfig({
     "@hey-api/typescript",
     {
       name: "zod",
+      // Attio's OpenAPI spec declares some timestamp fields with format "date"
+      // but the API actually returns full ISO 8601 datetimes (e.g. "2023-01-01T15:00:00.000000000Z"),
+      // causing z.iso.date() validation to fail. Override both formats to use z.iso.datetime().
+      "~resolvers": {
+        string(ctx) {
+          const { $, schema, symbols } = ctx;
+          const { z } = symbols;
+          if (schema.format === "date" || schema.format === "date-time") {
+            ctx.nodes.format = () => $(z).attr("iso").attr("datetime").call();
+          }
+        },
+      },
     },
     {
       name: "@hey-api/sdk",

--- a/src/generated/zod.gen.ts
+++ b/src/generated/zod.gen.ts
@@ -923,7 +923,7 @@ export const zInputValue = z.union([
         value: z.string()
     }),
     z.object({
-        value: z.iso.date()
+        value: z.iso.datetime()
     })
 ]);
 
@@ -1625,7 +1625,7 @@ export const zOutputValue = z.union([
     }),
     z.object({
         attribute_type: z.enum(['timestamp']),
-        value: z.iso.date()
+        value: z.iso.datetime()
     })
 ]);
 
@@ -3433,7 +3433,7 @@ export const zPostV2ObjectsByObjectRecordsQueryResponse = z.object({
                     ]))
                 }),
                 attribute_type: z.enum(['timestamp']),
-                value: z.iso.date()
+                value: z.iso.datetime()
             })
         ])))
     }))
@@ -4388,7 +4388,7 @@ export const zPostV2ObjectsByObjectRecordsResponse = z.object({
                     ]))
                 }),
                 attribute_type: z.enum(['timestamp']),
-                value: z.iso.date()
+                value: z.iso.datetime()
             })
         ])))
     })
@@ -5345,7 +5345,7 @@ export const zPutV2ObjectsByObjectRecordsResponse = z.object({
                     ]))
                 }),
                 attribute_type: z.enum(['timestamp']),
-                value: z.iso.date()
+                value: z.iso.datetime()
             })
         ])))
     })
@@ -6311,7 +6311,7 @@ export const zGetV2ObjectsByObjectRecordsByRecordIdResponse = z.object({
                     ]))
                 }),
                 attribute_type: z.enum(['timestamp']),
-                value: z.iso.date()
+                value: z.iso.datetime()
             })
         ])))
     })
@@ -7267,7 +7267,7 @@ export const zPatchV2ObjectsByObjectRecordsByRecordIdResponse = z.object({
                     ]))
                 }),
                 attribute_type: z.enum(['timestamp']),
-                value: z.iso.date()
+                value: z.iso.datetime()
             })
         ])))
     })
@@ -8223,7 +8223,7 @@ export const zPutV2ObjectsByObjectRecordsByRecordIdResponse = z.object({
                     ]))
                 }),
                 attribute_type: z.enum(['timestamp']),
-                value: z.iso.date()
+                value: z.iso.datetime()
             })
         ])))
     })
@@ -9172,7 +9172,7 @@ export const zGetV2ObjectsByObjectRecordsByRecordIdAttributesByAttributeValuesRe
                 ]))
             }),
             attribute_type: z.enum(['timestamp']),
-            value: z.iso.date()
+            value: z.iso.datetime()
         })
     ]))
 });
@@ -10326,7 +10326,7 @@ export const zPostV2ListsByListEntriesQueryResponse = z.object({
                     ]))
                 }),
                 attribute_type: z.enum(['timestamp']),
-                value: z.iso.date()
+                value: z.iso.datetime()
             })
         ])))
     }))
@@ -11284,7 +11284,7 @@ export const zPostV2ListsByListEntriesResponse = z.object({
                     ]))
                 }),
                 attribute_type: z.enum(['timestamp']),
-                value: z.iso.date()
+                value: z.iso.datetime()
             })
         ])))
     })
@@ -12242,7 +12242,7 @@ export const zPutV2ListsByListEntriesResponse = z.object({
                     ]))
                 }),
                 attribute_type: z.enum(['timestamp']),
-                value: z.iso.date()
+                value: z.iso.datetime()
             })
         ])))
     })
@@ -13209,7 +13209,7 @@ export const zGetV2ListsByListEntriesByEntryIdResponse = z.object({
                     ]))
                 }),
                 attribute_type: z.enum(['timestamp']),
-                value: z.iso.date()
+                value: z.iso.datetime()
             })
         ])))
     })
@@ -14166,7 +14166,7 @@ export const zPatchV2ListsByListEntriesByEntryIdResponse = z.object({
                     ]))
                 }),
                 attribute_type: z.enum(['timestamp']),
-                value: z.iso.date()
+                value: z.iso.datetime()
             })
         ])))
     })
@@ -15123,7 +15123,7 @@ export const zPutV2ListsByListEntriesByEntryIdResponse = z.object({
                     ]))
                 }),
                 attribute_type: z.enum(['timestamp']),
-                value: z.iso.date()
+                value: z.iso.datetime()
             })
         ])))
     })
@@ -16072,7 +16072,7 @@ export const zGetV2ListsByListEntriesByEntryIdAttributesByAttributeValuesRespons
                 ]))
             }),
             attribute_type: z.enum(['timestamp']),
-            value: z.iso.date()
+            value: z.iso.datetime()
         })
     ]))
 });

--- a/test/attio/datetime-resolver.spec.ts
+++ b/test/attio/datetime-resolver.spec.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { zInputValue, zOutputValue } from "../../src/generated/zod.gen";
+
+describe("datetime resolver", () => {
+  describe("zInputValue timestamp parsing", () => {
+    it("accepts nanosecond-precision ISO datetime", () => {
+      const result = zInputValue.safeParse({
+        value: "2023-01-01T15:00:00.000000000Z",
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts millisecond-precision ISO datetime", () => {
+      const result = zInputValue.safeParse({
+        value: "2023-01-01T15:00:00.000Z",
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts second-precision ISO datetime", () => {
+      const result = zInputValue.safeParse({
+        value: "2023-01-01T15:00:00Z",
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts datetime with timezone offset", () => {
+      const result = zInputValue.safeParse({
+        value: "2023-01-01T15:00:00.000000000+05:30",
+      });
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe("zOutputValue timestamp parsing", () => {
+    it("accepts nanosecond-precision ISO datetime", () => {
+      const result = zOutputValue.safeParse({
+        attribute_type: "timestamp",
+        value: "2023-01-01T15:00:00.000000000Z",
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts millisecond-precision ISO datetime", () => {
+      const result = zOutputValue.safeParse({
+        attribute_type: "timestamp",
+        value: "2023-01-01T15:00:00.000Z",
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("rejects plain date string for timestamp attribute", () => {
+      const result = zOutputValue.safeParse({
+        attribute_type: "timestamp",
+        value: "2023-01-01",
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("zInputValue interaction datetime parsing", () => {
+    it("accepts nanosecond-precision interacted_at", () => {
+      const result = zInputValue.safeParse({
+        interaction_type: "meeting",
+        interacted_at: "2023-06-15T10:30:00.000000000Z",
+        owner_actor: {},
+      });
+      expect(result.success).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## **User description**
### **User description**
Attio's OpenAPI spec declares timestamp fields with format "date" but the API returns full ISO 8601 datetimes (e.g. "2023-01-01T15:00:00.000000000Z"), causing z.iso.date() validation to fail. Add a custom resolver to openapi-ts config that overrides both "date" and "date-time" formats to use z.iso.datetime().


___

### **PR Type**
Bug fix


___

### **Description**
- Add custom resolver to openapi-ts config for timestamp format mismatch

- Override both "date" and "date-time" formats to use z.iso.datetime()

- Update generated Zod schemas to use z.iso.datetime() for timestamp fields

- Add comprehensive test suite for datetime validation across API endpoints


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["OpenAPI Spec<br/>date/date-time formats"] -->|Custom Resolver| B["openapi-ts Config<br/>Override to z.iso.datetime"]
  B -->|Code Generation| C["Generated Zod Schemas<br/>z.iso.datetime validation"]
  C -->|Validation| D["API Responses<br/>ISO 8601 datetimes"]
  E["Test Suite<br/>datetime-resolver.spec.ts"] -->|Validates| C
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>openapi-ts.config.ts</strong><dd><code>Add custom datetime resolver to openapi-ts config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openapi-ts.config.ts

<ul><li>Add custom resolver under zod plugin configuration<br> <li> Override string format handler for "date" and "date-time" formats<br> <li> Configure resolver to use z.iso.datetime() instead of z.iso.date()<br> <li> Include detailed comments explaining the Attio API timestamp mismatch</ul>


</details>


  </td>
  <td><a href="https://github.com/hbmartin/attio-ts-sdk/pull/27/files#diff-79d66c7b38d1f15f090ed9fe93687bcba062ee84313d2d12f4cea1f812d36268">+12/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Code generation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>zod.gen.ts</strong><dd><code>Update generated schemas to use z.iso.datetime()</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/generated/zod.gen.ts

<ul><li>Replace z.iso.date() with z.iso.datetime() in zInputValue schema<br> <li> Replace z.iso.date() with z.iso.datetime() in zOutputValue schema<br> <li> Update 16 timestamp field validations across multiple API endpoint <br>schemas<br> <li> Affects POST, PUT, PATCH, GET, and DELETE endpoint response/data <br>schemas</ul>


</details>


  </td>
  <td><a href="https://github.com/hbmartin/attio-ts-sdk/pull/27/files#diff-08839d7da01c648dcab587c59c2980bc7340296cff164aeb1e995cee8e1ae0cd">+16/-16</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>datetime-resolver.spec.ts</strong><dd><code>Add comprehensive datetime resolver test suite</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/attio/datetime-resolver.spec.ts

<ul><li>Add test suite for zInputValue timestamp parsing with multiple <br>precision levels<br> <li> Add test suite for zOutputValue timestamp parsing and validation<br> <li> Test nanosecond, millisecond, and second-precision ISO datetimes<br> <li> Test timezone offset handling and rejection of plain date strings</ul>


</details>


  </td>
  <td><a href="https://github.com/hbmartin/attio-ts-sdk/pull/27/files#diff-7043c5c11ea0524dba08a32fe4d7981e85c1261a9eda0fcf1bbdb1adefb92344">+71/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___


___

## **CodeAnt-AI Description**
**Fix timestamp validation: treat OpenAPI "date" fields as full ISO datetimes**

### What Changed
- Generated validation now accepts full ISO 8601 datetimes for timestamp fields (replaced occurrences of date-only validation with datetime validation)
- Code generation config overrides OpenAPI "date" and "date-time" formats so schemas validate nanosecond, millisecond, second, and timezone-offset datetimes
- New tests verify that API responses with various ISO datetime precisions are accepted and that plain date strings are rejected for timestamp attributes

### Impact
`✅ Accepts ISO 8601 datetimes from API responses`
`✅ Fewer response validation failures in client-side schema checks`
`✅ Tests now catch datetime-format mismatches`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced date and date-time format handling with ISO-8601 parser support for improved type generation and validation across multiple precision levels.

* **Tests**
  * Added comprehensive test coverage for datetime parsing validation with timezone and precision format support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->