### PR TITLE
feat: make SDK compatible with Deno and other non-Node runtimes

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -427,7 +427,7 @@
       "linter": {
         "rules": {
           "correctness": {
-            "noNodejsModules": "off"
+            "noProcessGlobal": "off"
           },
           "style": {
             "noProcessEnv": "off"

--- a/jsr.json
+++ b/jsr.json
@@ -1,5 +1,5 @@
 {
-  "name": "attio-ts-sdk",
+  "name": "@hbmartin/attio-ts-sdk",
   "version": "1.1.0",
   "license": "MIT",
   "exports": "./src/index.ts",

--- a/src/attio/config.ts
+++ b/src/attio/config.ts
@@ -1,8 +1,11 @@
-import process from "node:process";
 import type { Config, ResponseStyle } from "../generated/client";
 import type { AttioCacheConfig } from "./cache";
 import type { AttioClientHooks, AttioLogger } from "./hooks";
 import type { RetryConfig } from "./retry";
+
+declare const Deno:
+  | { env: { get(key: string): string | undefined } }
+  | undefined;
 
 const TRAILING_SLASHES_REGEX = /\/+$/;
 
@@ -25,10 +28,13 @@ interface AttioClientConfig
 }
 
 const getEnvValue = (key: string): string | undefined => {
-  if (typeof process === "undefined") {
-    return;
+  if (typeof Deno !== "undefined") {
+    return Deno.env.get(key);
   }
-  return process.env?.[key];
+  if (typeof process !== "undefined") {
+    return process.env?.[key];
+  }
+  return;
 };
 
 const normalizeBaseUrl = (baseUrl: string): string =>

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "tsdown";
 
 export default defineConfig({
   entry: { index: "./src/index.ts" },
-  platform: "node",
+  platform: "neutral",
   dts: true,
   sourcemap: true,
 });


### PR DESCRIPTION
## **User description**
### **User description**
Remove node:process import in favor of runtime-agnostic env access that tries Deno.env.get() first, then falls back to process global. Switch tsdown platform from "node" to "neutral" for runtime-agnostic bundles, and fix JSR package name to use required scope.


___

### **PR Type**
Enhancement


___

### **Description**
- Remove Node.js-specific imports for runtime compatibility

- Add Deno environment variable access with fallback

- Switch build platform from node to neutral

- Fix JSR package name to use required scope


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Node.js process import"] -->|Remove| B["Runtime-agnostic env access"]
  B -->|Try first| C["Deno.env.get"]
  B -->|Fallback| D["process.env"]
  E["Build platform: node"] -->|Change to| F["Build platform: neutral"]
  G["Package name: attio-ts-sdk"] -->|Update to| H["Package name: @hbmartin/attio-ts-sdk"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.ts</strong><dd><code>Runtime-agnostic environment variable access</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/attio/config.ts

<ul><li>Remove <code>node:process</code> import dependency<br> <li> Add Deno type declaration for runtime detection<br> <li> Implement <code>getEnvValue</code> function with Deno-first fallback strategy<br> <li> Check for Deno availability before process global</ul>


</details>


  </td>
  <td><a href="https://github.com/hbmartin/attio-ts-sdk/pull/29/files#diff-aff2a0fb187d7836574364e8f3ac8e7cab379be68039843a7925df3b4c2cc2f5">+10/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tsdown.config.ts</strong><dd><code>Switch to neutral platform for bundling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tsdown.config.ts

<ul><li>Change build platform from "node" to "neutral"<br> <li> Enables runtime-agnostic bundle generation</ul>


</details>


  </td>
  <td><a href="https://github.com/hbmartin/attio-ts-sdk/pull/29/files#diff-c105f99c241d6d60e41561e663ee096629894e9b2a773c82283655b323f59485">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>biome.jsonc</strong><dd><code>Update linter rules for process global</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

biome.jsonc

<ul><li>Replace <code>noNodejsModules</code> rule with <code>noProcessGlobal</code><br> <li> Aligns linter rules with new runtime-agnostic approach</ul>


</details>


  </td>
  <td><a href="https://github.com/hbmartin/attio-ts-sdk/pull/29/files#diff-955d6dd0b9089fa951f33ccabbab4597fe019091b7bb81e166df2b34dea4a906">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>jsr.json</strong><dd><code>Add scope to JSR package name</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

jsr.json

<ul><li>Update package name from <code>attio-ts-sdk</code> to <code>@hbmartin/attio-ts-sdk</code><br> <li> Adds required scope prefix for JSR registry</ul>


</details>


  </td>
  <td><a href="https://github.com/hbmartin/attio-ts-sdk/pull/29/files#diff-5193a148ebdd2baf23b4f0a1c1add7ea02a8b92fb022e3a5780e886509d06693">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___


___

## **CodeAnt-AI Description**
Make SDK runtime-agnostic and add Deno environment support

### What Changed
- SDK now reads environment variables from Deno first and falls back to Node, so configuration works in Deno and Node runtimes
- Build configuration changed to produce neutral/portable bundles instead of Node-only bundles
- Package name updated to the scoped name @hbmartin/attio-ts-sdk for correct publishing
- Lint settings adjusted to allow using the process global where needed

### Impact
`✅ Works in Deno without Node-only imports`
`✅ SDK picks up env vars in Deno and Node`
`✅ Correct package name for publishing`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Deno environments alongside Node.js for environment variable handling

* **Chores**
  * Updated package name to `@hbmartin/attio-ts-sdk`
  * Updated build configuration for platform neutrality
  * Updated linting configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->