### PR TITLE
feat: make input types generic to enable proper type inference

### DIFF
--- a/src/attio/records.ts
+++ b/src/attio/records.ts
@@ -69,73 +69,81 @@ type RecordValues = PostV2ObjectsByObjectRecordsData["body"]["data"]["values"];
 type RecordFilter = PostV2ObjectsByObjectRecordsQueryData["body"]["filter"];
 type RecordSorts = PostV2ObjectsByObjectRecordsQueryData["body"]["sorts"];
 
-interface RecordCreateInput extends AttioClientInput {
+interface RecordCreateInput<T extends AttioRecordLike = AttioRecordLike>
+  extends AttioClientInput {
   object: RecordObjectId;
   values: RecordValues;
-  itemSchema?: ZodType<AttioRecordLike>;
+  itemSchema?: ZodType<T>;
   options?: Omit<
     Options<PostV2ObjectsByObjectRecordsData>,
     "client" | "path" | "body"
   >;
 }
 
-interface RecordUpdateInput extends AttioClientInput {
+interface RecordUpdateInput<T extends AttioRecordLike = AttioRecordLike>
+  extends AttioClientInput {
   object: RecordObjectId;
   recordId: RecordId;
   values: RecordValues;
-  itemSchema?: ZodType<AttioRecordLike>;
+  itemSchema?: ZodType<T>;
   options?: Omit<
     Options<PatchV2ObjectsByObjectRecordsByRecordIdData>,
     "client" | "path" | "body"
   >;
 }
 
-interface RecordUpsertInput extends AttioClientInput {
+interface RecordUpsertInput<T extends AttioRecordLike = AttioRecordLike>
+  extends AttioClientInput {
   object: RecordObjectId;
   matchingAttribute: MatchingAttribute;
   values: RecordValues;
-  itemSchema?: ZodType<AttioRecordLike>;
+  itemSchema?: ZodType<T>;
   options?: Omit<
     Options<PutV2ObjectsByObjectRecordsData>,
     "client" | "path" | "body"
   >;
 }
 
-interface RecordGetInput extends AttioClientInput {
+interface RecordGetInput<T extends AttioRecordLike = AttioRecordLike>
+  extends AttioClientInput {
   object: RecordObjectId;
   recordId: RecordId;
-  itemSchema?: ZodType<AttioRecordLike>;
+  itemSchema?: ZodType<T>;
   options?: Omit<
     Options<GetV2ObjectsByObjectRecordsByRecordIdData>,
     "client" | "path"
   >;
 }
 
-interface RecordQueryBaseInput extends AttioClientInput {
+interface RecordQueryBaseInput<T extends AttioRecordLike = AttioRecordLike>
+  extends AttioClientInput {
   object: RecordObjectId;
   filter?: RecordFilter;
   sorts?: RecordSorts;
   limit?: number;
   offset?: number;
   signal?: AbortSignal;
-  itemSchema?: ZodType<AttioRecordLike>;
+  itemSchema?: ZodType<T>;
   options?: Omit<
     Options<PostV2ObjectsByObjectRecordsQueryData>,
     "client" | "path" | "body"
   >;
 }
 
-interface RecordQuerySingleInput extends RecordQueryBaseInput {
+interface RecordQuerySingleInput<T extends AttioRecordLike = AttioRecordLike>
+  extends RecordQueryBaseInput<T> {
   paginate?: false;
 }
 
-interface RecordQueryCollectInput extends RecordQueryBaseInput {
+interface RecordQueryCollectInput<T extends AttioRecordLike = AttioRecordLike>
+  extends RecordQueryBaseInput<T> {
   paginate: true;
   maxPages?: number;
   maxItems?: number;
 }
 
-interface RecordQueryStreamInput extends RecordQueryBaseInput {
+interface RecordQueryStreamInput<T extends AttioRecordLike = AttioRecordLike>
+  extends RecordQueryBaseInput<T> {
   paginate: "stream";
   maxPages?: number;
   maxItems?: number;
@@ -143,21 +151,21 @@ interface RecordQueryStreamInput extends RecordQueryBaseInput {
 
 type RecordQueryPaginationInput = SharedPaginationInput;
 
-type RecordQueryInput =
-  | RecordQuerySingleInput
-  | RecordQueryCollectInput
-  | RecordQueryStreamInput;
+type RecordQueryInput<T extends AttioRecordLike = AttioRecordLike> =
+  | RecordQuerySingleInput<T>
+  | RecordQueryCollectInput<T>
+  | RecordQueryStreamInput<T>;
 
 // Overload: With itemSchema - T is inferred from schema
 async function createRecord<T extends AttioRecordLike>(
-  input: WithItemSchema<RecordCreateInput, T>,
+  input: RecordCreateInput<T> & { itemSchema: ZodType<T> },
 ): Promise<T>;
-// Overload: Without itemSchema or base input - returns AttioRecordLike
+// Overload: Without itemSchema - returns AttioRecordLike
 async function createRecord(input: RecordCreateInput): Promise<AttioRecordLike>;
 // Implementation
-async function createRecord(
-  input: RecordCreateInput,
-): Promise<AttioRecordLike> {
+async function createRecord<T extends AttioRecordLike>(
+  input: RecordCreateInput<T>,
+): Promise<T | AttioRecordLike> {
   const client = resolveAttioClient(input);
   const schema = input.itemSchema ?? rawRecordSchema;
   const result = await postV2ObjectsByObjectRecords({
@@ -177,14 +185,14 @@ async function createRecord(
 
 // Overload: With itemSchema - T is inferred from schema
 async function updateRecord<T extends AttioRecordLike>(
-  input: WithItemSchema<RecordUpdateInput, T>,
+  input: RecordUpdateInput<T> & { itemSchema: ZodType<T> },
 ): Promise<T>;
-// Overload: Without itemSchema or base input - returns AttioRecordLike
+// Overload: Without itemSchema - returns AttioRecordLike
 async function updateRecord(input: RecordUpdateInput): Promise<AttioRecordLike>;
 // Implementation
-async function updateRecord(
-  input: RecordUpdateInput,
-): Promise<AttioRecordLike> {
+async function updateRecord<T extends AttioRecordLike>(
+  input: RecordUpdateInput<T>,
+): Promise<T | AttioRecordLike> {
   const client = resolveAttioClient(input);
   const schema = input.itemSchema ?? rawRecordSchema;
   const result = await patchV2ObjectsByObjectRecordsByRecordId({
@@ -204,14 +212,14 @@ async function updateRecord(
 
 // Overload: With itemSchema - T is inferred from schema
 async function upsertRecord<T extends AttioRecordLike>(
-  input: WithItemSchema<RecordUpsertInput, T>,
+  input: RecordUpsertInput<T> & { itemSchema: ZodType<T> },
 ): Promise<T>;
-// Overload: Without itemSchema or base input - returns AttioRecordLike
+// Overload: Without itemSchema - returns AttioRecordLike
 async function upsertRecord(input: RecordUpsertInput): Promise<AttioRecordLike>;
 // Implementation
-async function upsertRecord(
-  input: RecordUpsertInput,
-): Promise<AttioRecordLike> {
+async function upsertRecord<T extends AttioRecordLike>(
+  input: RecordUpsertInput<T>,
+): Promise<T | AttioRecordLike> {
   const client = resolveAttioClient(input);
   const schema = input.itemSchema ?? rawRecordSchema;
   const result = await putV2ObjectsByObjectRecords({
@@ -234,12 +242,14 @@ async function upsertRecord(
 
 // Overload: With itemSchema - T is inferred from schema
 async function getRecord<T extends AttioRecordLike>(
-  input: WithItemSchema<RecordGetInput, T>,
+  input: RecordGetInput<T> & { itemSchema: ZodType<T> },
 ): Promise<T>;
-// Overload: Without itemSchema or base input - returns AttioRecordLike
+// Overload: Without itemSchema - returns AttioRecordLike
 async function getRecord(input: RecordGetInput): Promise<AttioRecordLike>;
 // Implementation
-async function getRecord(input: RecordGetInput): Promise<AttioRecordLike> {
+async function getRecord<T extends AttioRecordLike>(
+  input: RecordGetInput<T>,
+): Promise<T | AttioRecordLike> {
   const client = resolveAttioClient(input);
   const schema = input.itemSchema ?? rawRecordSchema;
   const result = await getV2ObjectsByObjectRecordsByRecordId({
@@ -265,29 +275,30 @@ const deleteRecord = async (input: RecordGetInput): Promise<boolean> => {
 
 // Overload: Stream mode with itemSchema - T is inferred from schema
 function queryRecords<T extends AttioRecordLike>(
-  input: WithItemSchema<RecordQueryStreamInput, T>,
+  input: RecordQueryStreamInput<T> & { itemSchema: ZodType<T> },
 ): AsyncIterable<T>;
 // Overload: Stream mode without itemSchema - returns AttioRecordLike
 function queryRecords(
-  input: WithoutItemSchema<RecordQueryStreamInput>,
+  input: RecordQueryStreamInput,
 ): AsyncIterable<AttioRecordLike>;
 // Overload: Single/Collect mode with itemSchema - T is inferred from schema
 function queryRecords<T extends AttioRecordLike>(
-  input: WithItemSchema<RecordQuerySingleInput | RecordQueryCollectInput, T>,
+  input: (RecordQuerySingleInput<T> | RecordQueryCollectInput<T>) & {
+    itemSchema: ZodType<T>;
+  },
 ): Promise<T[]>;
 // Overload: Single/Collect mode without itemSchema - returns AttioRecordLike
 function queryRecords(
-  input: WithoutItemSchema<RecordQuerySingleInput | RecordQueryCollectInput>,
+  input: RecordQuerySingleInput | RecordQueryCollectInput,
 ): Promise<AttioRecordLike[]>;
 // Overload: Base input type (for SDK compatibility)
 function queryRecords(
   input: RecordQueryInput,
 ): Promise<AttioRecordLike[]> | AsyncIterable<AttioRecordLike>;
 // Implementation signature
-function queryRecords(
-  input: RecordQueryInput,
-): Promise<AttioRecordLike[]> | AsyncIterable<AttioRecordLike> {
-  type T = AttioRecordLike;
+function queryRecords<T extends AttioRecordLike>(
+  input: RecordQueryInput<T>,
+): Promise<T[]> | AsyncIterable<T> {
   const client = resolveAttioClient(input);
   const schema = input.itemSchema ?? rawRecordSchema;
 
@@ -310,7 +321,7 @@ function queryRecords(
     });
     const items = unwrapItems(result) as Record<string, unknown>[];
     const normalized = normalizeRecords(items);
-    return validateItemsArray(normalized, schema);
+    return validateItemsArray(normalized, schema) as T[];
   };
 
   if (input.paginate === "stream") {


### PR DESCRIPTION
## **CodeAnt-AI Description**
**Make input types generic and validate records after normalization**

### What Changed
- Input types for record, list, and search operations are now generic so the SDK infers item types from a provided schema (e.g., RecordCreateInput<T>, RecordQueryInput<T>).
- Schema validation now runs after normalization rather than before, so the validated shape matches the actual returned objects and avoids unsound casts.
- Removed redundant overload helpers and adjusted query/get/create/update/upsert/search functions to return items validated against the provided schema (including streamed and paginated flows).

### Impact
`✅ Clearer record types when passing a schema`
`✅ Fewer runtime validation mismatches for returned records`
`✅ Easier developer experience when using typed schemas`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Strengthened data validation mechanisms for list queries, record operations (create, update, upsert, get), and search functionality to ensure data integrity.
  * Enhanced type consistency and inference across query methods for improved API usability and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->