### PR TITLE
fix: use AttioFilter type for ListEntryFilter and RecordFilter

### DIFF
--- a/src/attio/lists.ts
+++ b/src/attio/lists.ts
@@ -16,6 +16,7 @@ import {
   postV2ListsByListEntriesQuery,
 } from "../generated";
 import { type AttioClientInput, resolveAttioClient } from "./client";
+import type { AttioFilter } from "./filters";
 import {
   paginateOffset,
   paginateOffsetAsync,
@@ -49,7 +50,7 @@ const createListId = (id: string): ListId => {
 };
 
 type EntryValues = PostV2ListsByListEntriesData["body"]["data"]["entry_values"];
-type ListEntryFilter = PostV2ListsByListEntriesQueryData["body"]["filter"];
+type ListEntryFilter = AttioFilter;
 
 interface ListQueryBaseInput<T extends AttioRecordLike = AttioRecordLike>
   extends AttioClientInput {
@@ -180,7 +181,8 @@ export function queryListEntries<T extends AttioRecordLike>(
       client,
       path: { list: input.list },
       body: {
-        filter: input.filter,
+        filter:
+          input.filter as PostV2ListsByListEntriesQueryData["body"]["filter"],
         limit,
         offset,
       },

--- a/src/attio/records.ts
+++ b/src/attio/records.ts
@@ -16,6 +16,7 @@ import {
   putV2ObjectsByObjectRecords,
 } from "../generated";
 import { type AttioClientInput, resolveAttioClient } from "./client";
+import type { AttioFilter } from "./filters";
 import {
   paginateOffset,
   paginateOffsetAsync,
@@ -66,7 +67,7 @@ type RecordId = string & { readonly __brand: "RecordId" };
 type MatchingAttribute = string & { readonly __brand: "MatchingAttribute" };
 
 type RecordValues = PostV2ObjectsByObjectRecordsData["body"]["data"]["values"];
-type RecordFilter = PostV2ObjectsByObjectRecordsQueryData["body"]["filter"];
+type RecordFilter = AttioFilter;
 type RecordSorts = PostV2ObjectsByObjectRecordsQueryData["body"]["sorts"];
 
 interface RecordCreateInput<T extends AttioRecordLike = AttioRecordLike>
@@ -311,7 +312,8 @@ function queryRecords<T extends AttioRecordLike>(
       client,
       path: { object: input.object },
       body: {
-        filter: input.filter,
+        filter:
+          input.filter as PostV2ObjectsByObjectRecordsQueryData["body"]["filter"],
         sorts: input.sorts,
         limit,
         offset,


### PR DESCRIPTION
## **User description**
This allows filters built with the `filters` helper to be used directly without requiring type assertions at call sites.


___

## **CodeAnt-AI Description**
Use AttioFilter type for record and list queries so filter helpers work without assertions

### What Changed
- Queries for records and list entries now accept filters built with the filters helper directly (no manual type assertions required).
- The library's internal types for record and list entry filters were replaced with the shared AttioFilter type.
- When sending query requests, filters are passed through with the correct declared type so developer code compiles without extra casts.

### Impact
`✅ Fewer compile-time filter type assertions in client code`
`✅ Simpler use of filters when querying records and lists`
`✅ Fewer type-related build errors when integrating filter helpers`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved type compatibility for filter operations to enhance code maintainability and consistency across the API integration layer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->