### PR TITLE
test(attio): add filter schema validation edge case tests

### DIFF
--- a/test/attio/filters.spec.ts
+++ b/test/attio/filters.spec.ts
@@ -317,6 +317,23 @@ describe("filters", () => {
       ).toThrow();
     });
 
+    it("rejects empty field condition in nested attribute", () => {
+      expect(() =>
+        attioFilterSchema.parse({ status: { sub_field: {} } }),
+      ).toThrow("Field condition must include at least one operator");
+    });
+
+    it("rejects attribute keys starting with $", () => {
+      expect(() =>
+        attioFilterSchema.parse({ $custom: { $eq: "value" } }),
+      ).toThrow();
+    });
+
+    it("allows non-$ attribute keys", () => {
+      const filter = { status: { $eq: "active" } };
+      expect(attioFilterSchema.parse(filter)).toEqual(filter);
+    });
+
     it("converts parsed filters to API-compatible record shape", () => {
       const filter = {
         status: { $eq: "active" },


### PR DESCRIPTION
## **User description**
Cover empty field condition rejection, $-prefixed attribute key rejection, and simplified parseAttioFilter passthrough.


___

## **CodeAnt-AI Description**
Enforce stricter filter validation and cover edge cases in tests

### What Changed
- Rejects nested field conditions that are empty and returns "Field condition must include at least one operator"
- Rejects attribute keys that start with '$' and adds a test to confirm this behavior
- Confirms valid non-'$' attribute keys are accepted
- Simplifies filter parsing to return the validated filter directly (no additional transformation)

### Impact
`✅ Clearer filter validation errors`
`✅ Fewer invalid filter submissions reaching the API`
`✅ Safer attribute keys (no $-prefixed attributes allowed)`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced filter validation to enforce field conditions include necessary operators and restrict attribute key naming patterns, preventing malformed filters from being accepted.

* **Tests**
  * Added test coverage for improved filter validation, verifying field condition requirements and attribute key constraints are properly enforced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->