### PR TITLE
refactor: add shared operation wrappers to reduce repeated request/un…

### DIFF
--- a/src/attio/index.ts
+++ b/src/attio/index.ts
@@ -12,6 +12,7 @@ export * from "./logging";
 export * from "./metadata";
 export * from "./notes";
 export * from "./objects";
+export * from "./operations";
 export * from "./pagination";
 export * from "./record-utils";
 export * from "./records";

--- a/src/attio/notes.ts
+++ b/src/attio/notes.ts
@@ -10,9 +10,13 @@ import {
   getV2NotesByNoteId,
   postV2Notes,
 } from "../generated";
-import { type AttioClientInput, resolveAttioClient } from "./client";
+import type { AttioClientInput } from "./client";
 import { type BrandedId, createBrandedId } from "./ids";
-import { unwrapData, unwrapItems } from "./response";
+import {
+  callAndDelete,
+  callAndUnwrapData,
+  callAndUnwrapItems,
+} from "./operations";
 
 type NoteId = BrandedId<"NoteId">;
 type NoteParentObjectId = BrandedId<"NoteParentObjectId">;
@@ -47,51 +51,45 @@ export interface NoteDeleteInput extends AttioClientInput {
   options?: Omit<Options<DeleteV2NotesByNoteIdData>, "client" | "path">;
 }
 
-export const listNotes = async (input: AttioClientInput = {}) => {
-  const client = resolveAttioClient(input);
-  const result = await getV2Notes({ client });
-  return unwrapItems(result);
-};
+export const listNotes = async (input: AttioClientInput = {}) =>
+  callAndUnwrapItems(input, (client) => getV2Notes({ client }));
 
-export const getNote = async (input: NoteGetInput) => {
-  const client = resolveAttioClient(input);
-  const result = await getV2NotesByNoteId({
-    client,
-    path: { note_id: input.noteId },
-    ...input.options,
-  });
-  return unwrapData(result);
-};
+export const getNote = async (input: NoteGetInput) =>
+  callAndUnwrapData(input, (client) =>
+    getV2NotesByNoteId({
+      client,
+      path: { note_id: input.noteId },
+      ...input.options,
+    }),
+  );
 
-export const createNote = async (input: NoteCreateInput) => {
-  const client = resolveAttioClient(input);
-  const result = await postV2Notes({
-    client,
-    body: {
-      data: {
-        parent_object: input.parentObject,
-        parent_record_id: input.parentRecordId,
-        title: input.title,
-        format: input.format,
-        content: input.content,
-        created_at: input.createdAt,
-        meeting_id: input.meetingId,
+export const createNote = async (input: NoteCreateInput) =>
+  callAndUnwrapData(input, (client) =>
+    postV2Notes({
+      client,
+      body: {
+        data: {
+          parent_object: input.parentObject,
+          parent_record_id: input.parentRecordId,
+          title: input.title,
+          format: input.format,
+          content: input.content,
+          created_at: input.createdAt,
+          meeting_id: input.meetingId,
+        },
       },
-    },
-    ...input.options,
-  });
-  return unwrapData(result);
-};
+      ...input.options,
+    }),
+  );
 
-export const deleteNote = async (input: NoteDeleteInput) => {
-  const client = resolveAttioClient(input);
-  await deleteV2NotesByNoteId({
-    client,
-    path: { note_id: input.noteId },
-    ...input.options,
-  });
-  return true;
-};
+export const deleteNote = async (input: NoteDeleteInput) =>
+  callAndDelete(input, (client) =>
+    deleteV2NotesByNoteId({
+      client,
+      path: { note_id: input.noteId },
+      ...input.options,
+    }),
+  );
 
 export { createNoteId, createNoteParentObjectId, createNoteParentRecordId };
 export type { NoteFormat, NoteId, NoteParentObjectId, NoteParentRecordId };

--- a/src/attio/objects.ts
+++ b/src/attio/objects.ts
@@ -13,8 +13,8 @@ import {
   patchV2ObjectsByObject,
   postV2Objects,
 } from "../generated";
-import { type AttioClientInput, resolveAttioClient } from "./client";
-import { unwrapData, unwrapItems } from "./response";
+import type { AttioClientInput } from "./client";
+import { callAndUnwrapData, callAndUnwrapItems } from "./operations";
 
 type ObjectSlug = string & { readonly __brand: "ObjectSlug" };
 type ObjectApiSlug = string & { readonly __brand: "ObjectApiSlug" };
@@ -60,37 +60,42 @@ interface UpdateObjectInput extends AttioClientInput {
 
 const listObjects = async (
   input: ListObjectsInput = {},
-): Promise<AttioObject[]> => {
-  const client = resolveAttioClient(input);
-  const result = await getV2Objects({ client, ...input.options });
-  return unwrapItems(result, { schema: AttioObjectSchema });
-};
+): Promise<AttioObject[]> =>
+  callAndUnwrapItems(
+    input,
+    (client) => getV2Objects({ client, ...input.options }),
+    { schema: AttioObjectSchema },
+  );
 
-const getObject = async (input: GetObjectInput): Promise<AttioObject> => {
-  const client = resolveAttioClient(input);
-  const result = await getV2ObjectsByObject({
-    client,
-    path: { object: input.object },
-    ...input.options,
-  });
-  return unwrapData(result, { schema: AttioObjectSchema });
-};
+const getObject = async (input: GetObjectInput): Promise<AttioObject> =>
+  callAndUnwrapData(
+    input,
+    (client) =>
+      getV2ObjectsByObject({
+        client,
+        path: { object: input.object },
+        ...input.options,
+      }),
+    { schema: AttioObjectSchema },
+  );
 
-const createObject = async (input: CreateObjectInput): Promise<AttioObject> => {
-  const client = resolveAttioClient(input);
-  const result = await postV2Objects({
-    client,
-    body: {
-      data: {
-        api_slug: input.apiSlug,
-        singular_noun: input.singularNoun,
-        plural_noun: input.pluralNoun,
-      },
-    },
-    ...input.options,
-  });
-  return unwrapData(result, { schema: AttioObjectSchema });
-};
+const createObject = async (input: CreateObjectInput): Promise<AttioObject> =>
+  callAndUnwrapData(
+    input,
+    (client) =>
+      postV2Objects({
+        client,
+        body: {
+          data: {
+            api_slug: input.apiSlug,
+            singular_noun: input.singularNoun,
+            plural_noun: input.pluralNoun,
+          },
+        },
+        ...input.options,
+      }),
+    { schema: AttioObjectSchema },
+  );
 
 const buildUpdateObjectData = (input: UpdateObjectInput): ObjectUpdateData => ({
   ...(input.apiSlug !== undefined && { api_slug: input.apiSlug }),
@@ -100,18 +105,18 @@ const buildUpdateObjectData = (input: UpdateObjectInput): ObjectUpdateData => ({
   ...(input.pluralNoun !== undefined && { plural_noun: input.pluralNoun }),
 });
 
-const updateObject = async (input: UpdateObjectInput): Promise<AttioObject> => {
-  const client = resolveAttioClient(input);
-  const result = await patchV2ObjectsByObject({
-    client,
-    path: { object: input.object },
-    body: {
-      data: buildUpdateObjectData(input),
-    },
-    ...input.options,
-  });
-  return unwrapData(result, { schema: AttioObjectSchema });
-};
+const updateObject = async (input: UpdateObjectInput): Promise<AttioObject> =>
+  callAndUnwrapData(
+    input,
+    (client) =>
+      patchV2ObjectsByObject({
+        client,
+        path: { object: input.object },
+        body: { data: buildUpdateObjectData(input) },
+        ...input.options,
+      }),
+    { schema: AttioObjectSchema },
+  );
 
 export type {
   CreateObjectInput,

--- a/src/attio/operations.ts
+++ b/src/attio/operations.ts
@@ -1,0 +1,104 @@
+import type { ZodType } from "zod";
+import {
+  type AttioClient,
+  type AttioClientInput,
+  resolveAttioClient,
+} from "./client";
+import {
+  type AttioRecordLike,
+  normalizeRecord,
+  normalizeRecords,
+} from "./record-utils";
+import {
+  assertOk,
+  type UnwrapItemsOptions,
+  type UnwrapOptions,
+  unwrapData,
+  unwrapItems,
+  validateItemsArray,
+  validateWithSchema,
+} from "./response";
+import { rawRecordSchema } from "./schemas";
+
+/**
+ * Resolve client, execute API call, and unwrap a single data response.
+ * Centralizes the resolveClient -> apiCall -> unwrapData pipeline
+ * used by tasks, objects, notes, and list entry operations.
+ */
+async function callAndUnwrapData<T>(
+  input: AttioClientInput,
+  apiCall: (client: AttioClient) => Promise<unknown>,
+  options?: UnwrapOptions<T>,
+): Promise<T> {
+  const client = resolveAttioClient(input);
+  const result = await apiCall(client);
+  return unwrapData<T>(result, options);
+}
+
+/**
+ * Resolve client, execute API call, and unwrap a list of items.
+ * Centralizes the resolveClient -> apiCall -> unwrapItems pipeline
+ * used by list, task, note, and workspace member operations.
+ */
+async function callAndUnwrapItems<T>(
+  input: AttioClientInput,
+  apiCall: (client: AttioClient) => Promise<unknown>,
+  options?: UnwrapItemsOptions<T>,
+): Promise<T[]> {
+  const client = resolveAttioClient(input);
+  const result = await apiCall(client);
+  return unwrapItems<T>(result, options);
+}
+
+/**
+ * Resolve client, execute API call, assert success, normalize a single record,
+ * and validate with schema. Centralizes the
+ * resolveClient -> apiCall -> assertOk -> normalizeRecord -> validateWithSchema
+ * pipeline used by single-record CRUD operations.
+ */
+async function callAndUnwrapRecord<T extends AttioRecordLike>(
+  input: AttioClientInput & { itemSchema?: ZodType<T> },
+  apiCall: (client: AttioClient) => Promise<unknown>,
+): Promise<T | AttioRecordLike> {
+  const client = resolveAttioClient(input);
+  const schema = input.itemSchema ?? rawRecordSchema;
+  const result = await apiCall(client);
+  const data = assertOk(result) as Record<string, unknown>;
+  const normalized = normalizeRecord(data);
+  return validateWithSchema(normalized, schema);
+}
+
+/**
+ * Unwrap items from a response, normalize as records, and validate.
+ * Used inside pagination fetch callbacks where client is already resolved.
+ */
+function unwrapAndNormalizeRecords<T>(
+  result: unknown,
+  schema: ZodType<T>,
+): T[] {
+  const items = unwrapItems(result) as Record<string, unknown>[];
+  const normalized = normalizeRecords(items);
+  return validateItemsArray(normalized, schema) as T[];
+}
+
+/**
+ * Resolve client, execute a delete API call, and return true.
+ * Centralizes the resolveClient -> apiCall -> return true pipeline
+ * used by delete operations.
+ */
+async function callAndDelete(
+  input: AttioClientInput,
+  apiCall: (client: AttioClient) => Promise<unknown>,
+): Promise<true> {
+  const client = resolveAttioClient(input);
+  await apiCall(client);
+  return true;
+}
+
+export {
+  callAndDelete,
+  callAndUnwrapData,
+  callAndUnwrapItems,
+  callAndUnwrapRecord,
+  unwrapAndNormalizeRecords,
+};

--- a/src/attio/search.ts
+++ b/src/attio/search.ts
@@ -2,8 +2,8 @@ import type { ZodType } from "zod";
 import type { Options, PostV2ObjectsRecordsSearchData } from "../generated";
 import { postV2ObjectsRecordsSearch } from "../generated";
 import { type AttioClientInput, resolveAttioClient } from "./client";
-import { type AttioRecordLike, normalizeRecords } from "./record-utils";
-import { unwrapItems, validateItemsArray } from "./response";
+import { unwrapAndNormalizeRecords } from "./operations";
+import type { AttioRecordLike } from "./record-utils";
 import { rawRecordSchema } from "./schemas";
 
 /**
@@ -52,9 +52,7 @@ export async function searchRecords<T extends AttioRecordLike>(
     ...input.options,
   });
 
-  const items = unwrapItems(result) as Record<string, unknown>[];
-  const normalized = normalizeRecords(items);
-  return validateItemsArray(normalized, schema) as T[];
+  return unwrapAndNormalizeRecords(result, schema) as T[];
 }
 
 export type { InferSearchResultType };

--- a/src/attio/tasks.ts
+++ b/src/attio/tasks.ts
@@ -17,7 +17,7 @@ import {
 import { zTask } from "../generated/zod.gen";
 import { type AttioClientInput, resolveAttioClient } from "./client";
 import { type BrandedId, createBrandedId } from "./ids";
-import { unwrapData, unwrapItems } from "./response";
+import { callAndUnwrapData, callAndUnwrapItems } from "./operations";
 
 type Task = z.infer<typeof zTask>;
 
@@ -51,46 +51,47 @@ export interface TaskGetInput extends AttioClientInput {
 
 export const listTasks = async (
   input: AttioClientInput = {},
-): Promise<Task[]> => {
-  const client = resolveAttioClient(input);
-  const result = await getV2Tasks({ client });
-  return unwrapItems(result, { schema: zTask });
-};
-
-export const getTask = async (input: TaskGetInput): Promise<Task> => {
-  const client = resolveAttioClient(input);
-  const result = await getV2TasksByTaskId({
-    client,
-    path: { task_id: input.taskId },
-    ...input.options,
+): Promise<Task[]> =>
+  callAndUnwrapItems(input, (client) => getV2Tasks({ client }), {
+    schema: zTask,
   });
-  return unwrapData(result, { schema: zTask });
-};
 
-export const createTask = async (input: TaskCreateInput): Promise<Task> => {
-  const client = resolveAttioClient(input);
-  const result = await postV2Tasks({
-    client,
-    body: {
-      data: input.data,
-    },
-    ...input.options,
-  });
-  return unwrapData(result, { schema: zTask });
-};
+export const getTask = async (input: TaskGetInput): Promise<Task> =>
+  callAndUnwrapData(
+    input,
+    (client) =>
+      getV2TasksByTaskId({
+        client,
+        path: { task_id: input.taskId },
+        ...input.options,
+      }),
+    { schema: zTask },
+  );
 
-export const updateTask = async (input: TaskUpdateInput): Promise<Task> => {
-  const client = resolveAttioClient(input);
-  const result = await patchV2TasksByTaskId({
-    client,
-    path: { task_id: input.taskId },
-    body: {
-      data: input.data,
-    },
-    ...input.options,
-  });
-  return unwrapData(result, { schema: zTask });
-};
+export const createTask = async (input: TaskCreateInput): Promise<Task> =>
+  callAndUnwrapData(
+    input,
+    (client) =>
+      postV2Tasks({
+        client,
+        body: { data: input.data },
+        ...input.options,
+      }),
+    { schema: zTask },
+  );
+
+export const updateTask = async (input: TaskUpdateInput): Promise<Task> =>
+  callAndUnwrapData(
+    input,
+    (client) =>
+      patchV2TasksByTaskId({
+        client,
+        path: { task_id: input.taskId },
+        body: { data: input.data },
+        ...input.options,
+      }),
+    { schema: zTask },
+  );
 
 export const deleteTask = async (
   input: TaskDeleteInput,

--- a/src/attio/workspace-members.ts
+++ b/src/attio/workspace-members.ts
@@ -2,9 +2,9 @@ import {
   getV2WorkspaceMembers,
   getV2WorkspaceMembersByWorkspaceMemberId,
 } from "../generated";
-import { type AttioClientInput, resolveAttioClient } from "./client";
+import type { AttioClientInput } from "./client";
 import { type BrandedId, createBrandedId } from "./ids";
-import { unwrapData, unwrapItems } from "./response";
+import { callAndUnwrapData, callAndUnwrapItems } from "./operations";
 
 type WorkspaceMemberId = BrandedId<"WorkspaceMemberId">;
 
@@ -15,20 +15,16 @@ interface WorkspaceMemberInput extends AttioClientInput {
   workspaceMemberId: WorkspaceMemberId;
 }
 
-export const listWorkspaceMembers = async (input: AttioClientInput = {}) => {
-  const client = resolveAttioClient(input);
-  const result = await getV2WorkspaceMembers({ client });
-  return unwrapItems(result);
-};
-
-export const getWorkspaceMember = async (input: WorkspaceMemberInput) => {
-  const client = resolveAttioClient(input);
-  const result = await getV2WorkspaceMembersByWorkspaceMemberId({
-    client,
-    path: { workspace_member_id: input.workspaceMemberId },
-  });
-  return unwrapData(result);
-};
-
 export { createWorkspaceMemberId };
 export type { WorkspaceMemberId };
+
+export const listWorkspaceMembers = async (input: AttioClientInput = {}) =>
+  callAndUnwrapItems(input, (client) => getV2WorkspaceMembers({ client }));
+
+export const getWorkspaceMember = async (input: WorkspaceMemberInput) =>
+  callAndUnwrapData(input, (client) =>
+    getV2WorkspaceMembersByWorkspaceMemberId({
+      client,
+      path: { workspace_member_id: input.workspaceMemberId },
+    }),
+  );

--- a/test/attio/operations.spec.ts
+++ b/test/attio/operations.spec.ts
@@ -1,0 +1,223 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+
+const resolveAttioClient = vi.fn();
+
+vi.mock("../../src/attio/client", () => ({
+  resolveAttioClient,
+}));
+
+describe("operations", () => {
+  let callAndUnwrapData: typeof import("../../src/attio/operations").callAndUnwrapData;
+  let callAndUnwrapItems: typeof import("../../src/attio/operations").callAndUnwrapItems;
+  let callAndUnwrapRecord: typeof import("../../src/attio/operations").callAndUnwrapRecord;
+  let unwrapAndNormalizeRecords: typeof import("../../src/attio/operations").unwrapAndNormalizeRecords;
+  let callAndDelete: typeof import("../../src/attio/operations").callAndDelete;
+
+  beforeAll(async () => {
+    ({
+      callAndUnwrapData,
+      callAndUnwrapItems,
+      callAndUnwrapRecord,
+      unwrapAndNormalizeRecords,
+      callAndDelete,
+    } = await import("../../src/attio/operations"));
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resolveAttioClient.mockReturnValue({ id: "mock-client" });
+  });
+
+  describe("callAndUnwrapData", () => {
+    it("resolves client and unwraps nested data", async () => {
+      const apiCall = vi.fn().mockResolvedValue({
+        data: { data: { name: "test" } },
+      });
+
+      const result = await callAndUnwrapData({ apiKey: "key-1" }, apiCall);
+
+      expect(resolveAttioClient).toHaveBeenCalledWith({ apiKey: "key-1" });
+      expect(apiCall).toHaveBeenCalledWith({ id: "mock-client" });
+      expect(result).toEqual({ name: "test" });
+    });
+
+    it("validates with schema when provided", async () => {
+      const schema = z.object({ name: z.string() });
+      const apiCall = vi.fn().mockResolvedValue({
+        data: { name: "valid" },
+      });
+
+      const result = await callAndUnwrapData({}, apiCall, { schema });
+
+      expect(result).toEqual({ name: "valid" });
+    });
+
+    it("throws on schema validation failure", async () => {
+      const schema = z.object({ name: z.string() });
+      const apiCall = vi.fn().mockResolvedValue({
+        data: { name: 123 },
+      });
+
+      await expect(callAndUnwrapData({}, apiCall, { schema })).rejects.toThrow(
+        "schema mismatch",
+      );
+    });
+
+    it("propagates API call errors", async () => {
+      const apiCall = vi.fn().mockRejectedValue(new Error("network failure"));
+
+      await expect(callAndUnwrapData({}, apiCall)).rejects.toThrow(
+        "network failure",
+      );
+    });
+  });
+
+  describe("callAndUnwrapItems", () => {
+    it("resolves client and unwraps item arrays", async () => {
+      const items = [{ id: 1 }, { id: 2 }];
+      const apiCall = vi.fn().mockResolvedValue({
+        data: { data: items },
+      });
+
+      const result = await callAndUnwrapItems({ apiKey: "key-2" }, apiCall);
+
+      expect(resolveAttioClient).toHaveBeenCalledWith({ apiKey: "key-2" });
+      expect(apiCall).toHaveBeenCalledWith({ id: "mock-client" });
+      expect(result).toEqual(items);
+    });
+
+    it("validates items with schema when provided", async () => {
+      const schema = z.object({ id: z.number() });
+      const apiCall = vi.fn().mockResolvedValue({
+        data: { data: [{ id: 1 }, { id: 2 }] },
+      });
+
+      const result = await callAndUnwrapItems({}, apiCall, { schema });
+
+      expect(result).toEqual([{ id: 1 }, { id: 2 }]);
+    });
+
+    it("returns empty array when no items found", async () => {
+      const apiCall = vi.fn().mockResolvedValue({
+        data: { data: "not-an-array" },
+      });
+
+      const result = await callAndUnwrapItems({}, apiCall);
+
+      expect(result).toEqual([]);
+    });
+
+    it("throws on schema validation failure for items", async () => {
+      const schema = z.object({ id: z.number() });
+      const apiCall = vi.fn().mockResolvedValue({
+        data: { data: [{ id: "not-a-number" }] },
+      });
+
+      await expect(callAndUnwrapItems({}, apiCall, { schema })).rejects.toThrow(
+        "schema mismatch",
+      );
+    });
+  });
+
+  describe("callAndUnwrapRecord", () => {
+    it("resolves client, asserts OK, normalizes, and validates", async () => {
+      const apiCall = vi.fn().mockResolvedValue({
+        data: {
+          data: {
+            id: { record_id: "rec-1" },
+            values: { name: [{ value: "Test" }] },
+          },
+        },
+      });
+
+      const result = await callAndUnwrapRecord({}, apiCall);
+
+      expect(resolveAttioClient).toHaveBeenCalledWith({});
+      expect(apiCall).toHaveBeenCalledWith({ id: "mock-client" });
+      expect(result).toHaveProperty("id");
+      expect(result).toHaveProperty("values");
+    });
+
+    it("uses custom itemSchema when provided", async () => {
+      const schema = z.object({ custom: z.string() }).passthrough();
+      const apiCall = vi.fn().mockResolvedValue({
+        data: {
+          data: {
+            id: { record_id: "rec-1" },
+            values: { field: "value" },
+            custom: "extra",
+          },
+        },
+      });
+
+      const result = await callAndUnwrapRecord({ itemSchema: schema }, apiCall);
+
+      expect(result).toHaveProperty("custom", "extra");
+    });
+
+    it("throws on error responses", async () => {
+      const apiCall = vi.fn().mockResolvedValue({
+        data: undefined,
+        error: { message: "Not found" },
+      });
+
+      await expect(callAndUnwrapRecord({}, apiCall)).rejects.toThrow();
+    });
+  });
+
+  describe("unwrapAndNormalizeRecords", () => {
+    it("unwraps items, normalizes records, and validates", () => {
+      const schema = z.record(z.string(), z.unknown());
+      const input = {
+        data: {
+          data: [
+            {
+              id: { record_id: "rec-1" },
+              values: { name: [{ value: "A" }] },
+            },
+            {
+              id: { record_id: "rec-2" },
+              values: { name: [{ value: "B" }] },
+            },
+          ],
+        },
+      };
+
+      const result = unwrapAndNormalizeRecords(input, schema);
+
+      expect(result).toHaveLength(2);
+      expect(result[0]).toHaveProperty("id");
+      expect(result[1]).toHaveProperty("values");
+    });
+
+    it("returns empty array for no items", () => {
+      const schema = z.record(z.string(), z.unknown());
+
+      const result = unwrapAndNormalizeRecords(
+        { data: { data: "not-array" } },
+        schema,
+      );
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("callAndDelete", () => {
+    it("resolves client, executes delete, and returns true", async () => {
+      const apiCall = vi.fn().mockResolvedValue(undefined);
+
+      const result = await callAndDelete({ apiKey: "key-3" }, apiCall);
+
+      expect(resolveAttioClient).toHaveBeenCalledWith({ apiKey: "key-3" });
+      expect(apiCall).toHaveBeenCalledWith({ id: "mock-client" });
+      expect(result).toBe(true);
+    });
+
+    it("propagates API call errors", async () => {
+      const apiCall = vi.fn().mockRejectedValue(new Error("delete failed"));
+
+      await expect(callAndDelete({}, apiCall)).rejects.toThrow("delete failed");
+    });
+  });
+});


### PR DESCRIPTION
## **User description**
…wrap/validate flow

Introduce operations.ts with five composable wrappers (callAndUnwrapData, callAndUnwrapItems, callAndUnwrapRecord, unwrapAndNormalizeRecords, callAndDelete) that centralize the resolveClient -> apiCall -> transform pipeline repeated across all domain modules.

Refactored records, lists, tasks, notes, objects, search, and workspace-members to use the shared wrappers, reducing ~50 lines of duplicated orchestration code while preserving all existing behavior.


___

## **CodeAnt-AI Description**
Add centralized operation wrappers and tests to standardize API call handling

### What Changed
- Added a new operations module that centralizes client resolution, API call execution, response unwrapping, record normalization, validation, and delete semantics.
- Replaced repeated request/unwrap/validate code in notes, lists, objects, records, tasks, search, and workspace-members with the new wrappers so these functions now use the shared behavior.
- Exported the operations from the public index so callers and other modules can use the shared wrappers.
- Added tests that verify client resolution, unwrapping, normalization, schema validation, delete behavior, and error propagation for the new wrappers.

### Impact
`✅ Consistent API response validation`
`✅ Fewer duplicated request/unwrap paths across modules`
`✅ Clearer, tested error propagation for API calls`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated API interaction patterns across record, list, task, note, and workspace member operations for improved maintainability.
  * Internal implementation updates preserve all existing public function signatures and behavior.

* **Tests**
  * Added comprehensive test coverage for the operations module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->