### PR TITLE
feat: value schemas and typed accessors

### DIFF
--- a/src/attio/index.ts
+++ b/src/attio/index.ts
@@ -22,5 +22,6 @@ export * from "./schema";
 export * from "./sdk";
 export * from "./search";
 export * from "./tasks";
+export * from "./value-schemas";
 export * from "./values";
 export * from "./workspace-members";

--- a/src/attio/value-schemas.ts
+++ b/src/attio/value-schemas.ts
@@ -1,0 +1,230 @@
+import { z } from "zod";
+
+// --- Scalar value schemas (extract the primary scalar from each value type) ---
+
+const textValueSchema = z.object({ value: z.string() }).passthrough();
+type TextValue = z.infer<typeof textValueSchema>;
+
+const numberValueSchema = z.object({ value: z.number() }).passthrough();
+type NumberValue = z.infer<typeof numberValueSchema>;
+
+const checkboxValueSchema = z.object({ value: z.boolean() }).passthrough();
+type CheckboxValue = z.infer<typeof checkboxValueSchema>;
+
+const dateValueSchema = z
+  .object({ value: z.string(), attribute_type: z.literal("date").optional() })
+  .passthrough();
+type DateValue = z.infer<typeof dateValueSchema>;
+
+const timestampValueSchema = z
+  .object({
+    value: z.string(),
+    attribute_type: z.literal("timestamp").optional(),
+  })
+  .passthrough();
+type TimestampValue = z.infer<typeof timestampValueSchema>;
+
+const ratingValueSchema = z
+  .object({ value: z.number().min(0).max(5) })
+  .passthrough();
+type RatingValue = z.infer<typeof ratingValueSchema>;
+
+const currencyValueSchema = z
+  .object({
+    currency_value: z.number(),
+    currency_code: z.string().optional(),
+  })
+  .passthrough();
+type CurrencyValue = z.infer<typeof currencyValueSchema>;
+
+const domainValueSchema = z
+  .object({ domain: z.string(), root_domain: z.string().optional() })
+  .passthrough();
+type DomainValue = z.infer<typeof domainValueSchema>;
+
+const emailValueSchema = z
+  .object({
+    original_email_address: z.string(),
+    email_address: z.string(),
+    email_domain: z.string().optional(),
+    email_root_domain: z.string().optional(),
+    email_local_specifier: z.string().optional(),
+  })
+  .passthrough();
+type EmailValue = z.infer<typeof emailValueSchema>;
+
+const phoneValueSchema = z
+  .object({
+    original_phone_number: z.string(),
+    phone_number: z.string(),
+    country_code: z.string().optional(),
+  })
+  .passthrough();
+type PhoneValue = z.infer<typeof phoneValueSchema>;
+
+const personalNameValueSchema = z
+  .object({
+    first_name: z.string(),
+    last_name: z.string(),
+    full_name: z.string(),
+  })
+  .passthrough();
+type PersonalNameValue = z.infer<typeof personalNameValueSchema>;
+
+const locationValueSchema = z
+  .object({
+    line_1: z.string().nullable(),
+    line_2: z.string().nullable(),
+    line_3: z.string().nullable(),
+    line_4: z.string().nullable(),
+    locality: z.string().nullable(),
+    region: z.string().nullable(),
+    postcode: z.string().nullable(),
+    country_code: z.string().nullable(),
+    latitude: z.string().nullable(),
+    longitude: z.string().nullable(),
+  })
+  .passthrough();
+type LocationValue = z.infer<typeof locationValueSchema>;
+
+const recordReferenceValueSchema = z
+  .object({
+    target_object: z.string(),
+    target_record_id: z.string(),
+  })
+  .passthrough();
+type RecordReferenceValue = z.infer<typeof recordReferenceValueSchema>;
+
+const actorReferenceValueSchema = z
+  .object({
+    referenced_actor_type: z.enum([
+      "api-token",
+      "workspace-member",
+      "system",
+      "app",
+    ]),
+    referenced_actor_id: z.string().nullable(),
+  })
+  .passthrough();
+type ActorReferenceValue = z.infer<typeof actorReferenceValueSchema>;
+
+const interactionValueSchema = z
+  .object({
+    interaction_type: z.enum([
+      "calendar-event",
+      "call",
+      "chat-thread",
+      "email",
+      "in-person-meeting",
+      "meeting",
+    ]),
+    interacted_at: z.string(),
+    owner_actor: z
+      .object({
+        id: z.string().optional(),
+        type: z
+          .enum(["api-token", "workspace-member", "system", "app"])
+          .optional(),
+      })
+      .passthrough(),
+  })
+  .passthrough();
+type InteractionValue = z.infer<typeof interactionValueSchema>;
+
+// --- Enriched object schemas for select/status (API returns these when hydrated) ---
+
+const selectOptionObjectSchema = z.object({ title: z.string() }).passthrough();
+
+const selectValueSchema = z
+  .object({ option: z.union([z.string(), selectOptionObjectSchema]) })
+  .passthrough();
+type SelectValue = z.infer<typeof selectValueSchema>;
+
+const enrichedSelectValueSchema = z
+  .object({ option: selectOptionObjectSchema })
+  .passthrough();
+type EnrichedSelectValue = z.infer<typeof enrichedSelectValueSchema>;
+
+const statusObjectSchema = z.object({ title: z.string() }).passthrough();
+
+const statusValueSchema = z
+  .object({ status: z.union([z.string(), statusObjectSchema]) })
+  .passthrough();
+type StatusValue = z.infer<typeof statusValueSchema>;
+
+const enrichedStatusValueSchema = z
+  .object({ status: statusObjectSchema })
+  .passthrough();
+type EnrichedStatusValue = z.infer<typeof enrichedStatusValueSchema>;
+
+// --- Lookup table mapping attribute_type to its schema ---
+
+const valueSchemasByType = {
+  text: textValueSchema,
+  number: numberValueSchema,
+  checkbox: checkboxValueSchema,
+  date: dateValueSchema,
+  timestamp: timestampValueSchema,
+  rating: ratingValueSchema,
+  currency: currencyValueSchema,
+  domain: domainValueSchema,
+  "email-address": emailValueSchema,
+  "phone-number": phoneValueSchema,
+  "personal-name": personalNameValueSchema,
+  location: locationValueSchema,
+  "record-reference": recordReferenceValueSchema,
+  "actor-reference": actorReferenceValueSchema,
+  interaction: interactionValueSchema,
+  select: selectValueSchema,
+  status: statusValueSchema,
+} as const;
+
+type ValueAttributeType = keyof typeof valueSchemasByType;
+
+export {
+  actorReferenceValueSchema,
+  checkboxValueSchema,
+  currencyValueSchema,
+  dateValueSchema,
+  domainValueSchema,
+  emailValueSchema,
+  enrichedSelectValueSchema,
+  enrichedStatusValueSchema,
+  interactionValueSchema,
+  locationValueSchema,
+  numberValueSchema,
+  personalNameValueSchema,
+  phoneValueSchema,
+  ratingValueSchema,
+  recordReferenceValueSchema,
+  selectOptionObjectSchema,
+  selectValueSchema,
+  statusObjectSchema,
+  statusValueSchema,
+  textValueSchema,
+  timestampValueSchema,
+  valueSchemasByType,
+};
+
+export type {
+  ActorReferenceValue,
+  CheckboxValue,
+  CurrencyValue,
+  DateValue,
+  DomainValue,
+  EmailValue,
+  EnrichedSelectValue,
+  EnrichedStatusValue,
+  InteractionValue,
+  LocationValue,
+  NumberValue,
+  PersonalNameValue,
+  PhoneValue,
+  RatingValue,
+  RecordReferenceValue,
+  SelectValue,
+  StatusValue,
+  TextValue,
+  TimestampValue,
+  ValueAttributeType,
+};

--- a/src/attio/values.ts
+++ b/src/attio/values.ts
@@ -2,6 +2,21 @@ import { z } from "zod";
 import type { InputValue } from "../generated";
 import { AttioResponseError } from "./errors";
 import type { AttioRecordLike } from "./record-utils";
+import {
+  checkboxValueSchema,
+  currencyValueSchema,
+  dateValueSchema,
+  domainValueSchema,
+  emailValueSchema,
+  enrichedSelectValueSchema,
+  enrichedStatusValueSchema,
+  numberValueSchema,
+  personalNameValueSchema,
+  phoneValueSchema,
+  ratingValueSchema,
+  textValueSchema,
+  timestampValueSchema,
+} from "./value-schemas";
 
 interface ValueCurrencyInput {
   currency_value: number;
@@ -182,7 +197,147 @@ const getFirstValueSafe = <T>(
   return { ok: true, value: result.value?.[0] };
 };
 
-export { getFirstValue, getFirstValueSafe, getValue, getValueSafe, value };
+const extractFirstScalar = <T, R>(
+  record: AttioRecordLike,
+  attribute: string,
+  schema: z.ZodType<T>,
+  extract: (parsed: T) => R,
+): R | undefined => {
+  const result = getFirstValueSafe(record, attribute, schema);
+  if (!result.ok || result.value === undefined) {
+    return;
+  }
+  return extract(result.value);
+};
+
+const getFirstText = (
+  record: AttioRecordLike,
+  attribute: string,
+): string | undefined =>
+  extractFirstScalar(record, attribute, textValueSchema, (v) => v.value);
+
+const getFirstNumber = (
+  record: AttioRecordLike,
+  attribute: string,
+): number | undefined =>
+  extractFirstScalar(record, attribute, numberValueSchema, (v) => v.value);
+
+const getFirstDate = (
+  record: AttioRecordLike,
+  attribute: string,
+): string | undefined =>
+  extractFirstScalar(record, attribute, dateValueSchema, (v) => v.value);
+
+const getFirstTimestamp = (
+  record: AttioRecordLike,
+  attribute: string,
+): string | undefined =>
+  extractFirstScalar(record, attribute, timestampValueSchema, (v) => v.value);
+
+const getFirstCheckbox = (
+  record: AttioRecordLike,
+  attribute: string,
+): boolean | undefined =>
+  extractFirstScalar(record, attribute, checkboxValueSchema, (v) => v.value);
+
+const getFirstRating = (
+  record: AttioRecordLike,
+  attribute: string,
+): number | undefined =>
+  extractFirstScalar(record, attribute, ratingValueSchema, (v) => v.value);
+
+const getFirstCurrencyValue = (
+  record: AttioRecordLike,
+  attribute: string,
+): number | undefined =>
+  extractFirstScalar(
+    record,
+    attribute,
+    currencyValueSchema,
+    (v) => v.currency_value,
+  );
+
+const getFirstSelectTitle = (
+  record: AttioRecordLike,
+  attribute: string,
+): string | undefined =>
+  extractFirstScalar(
+    record,
+    attribute,
+    enrichedSelectValueSchema,
+    (v) => v.option.title,
+  );
+
+const getFirstStatusTitle = (
+  record: AttioRecordLike,
+  attribute: string,
+): string | undefined =>
+  extractFirstScalar(
+    record,
+    attribute,
+    enrichedStatusValueSchema,
+    (v) => v.status.title,
+  );
+
+const getFirstFullName = (
+  record: AttioRecordLike,
+  attribute: string,
+): string | undefined =>
+  extractFirstScalar(
+    record,
+    attribute,
+    personalNameValueSchema,
+    (v) => v.full_name,
+  );
+
+const getFirstEmail = (
+  record: AttioRecordLike,
+  attribute: string,
+): string | undefined =>
+  extractFirstScalar(
+    record,
+    attribute,
+    emailValueSchema,
+    (v) => v.email_address,
+  );
+
+const getFirstDomain = (
+  record: AttioRecordLike,
+  attribute: string,
+): string | undefined =>
+  extractFirstScalar(record, attribute, domainValueSchema, (v) => v.domain);
+
+const getFirstPhone = (
+  record: AttioRecordLike,
+  attribute: string,
+): string | undefined =>
+  extractFirstScalar(
+    record,
+    attribute,
+    phoneValueSchema,
+    (v) => v.phone_number,
+  );
+
+export {
+  getFirstCheckbox,
+  getFirstCurrencyValue,
+  getFirstDate,
+  getFirstDomain,
+  getFirstEmail,
+  getFirstFullName,
+  getFirstNumber,
+  getFirstPhone,
+  getFirstRating,
+  getFirstSelectTitle,
+  getFirstStatusTitle,
+  getFirstText,
+  getFirstTimestamp,
+  getFirstValue,
+  getFirstValueSafe,
+  getValue,
+  getValueSafe,
+  value,
+};
 export type {
   ValueCurrencyInput,
   ValueFactory,

--- a/test/attio/schema.spec.ts
+++ b/test/attio/schema.spec.ts
@@ -8,6 +8,28 @@ vi.mock("../../src/attio/metadata", () => ({
   listAttributes: vi.fn(),
 }));
 
+const mockAttribute = (slug: string, type: string) => ({
+  id: { workspace_id: "w1", object_id: "o1", attribute_id: `a_${slug}` },
+  title: slug,
+  description: null,
+  api_slug: slug,
+  type,
+  is_system_attribute: false,
+  is_writable: true,
+  is_required: false,
+  is_unique: false,
+  is_multiselect: false,
+  is_default_value_enabled: false,
+  is_archived: false,
+  default_value: null,
+  relationship: null,
+  created_at: "2024-01-01T00:00:00Z",
+  config: {
+    currency: { default_currency_code: "USD", display_type: "code" },
+    record_reference: { allowed_object_ids: null },
+  },
+});
+
 describe("createSchema", () => {
   it("builds attribute accessors", async () => {
     const mockList = vi.mocked(listAttributes);
@@ -271,5 +293,239 @@ describe("createSchema", () => {
 
     const values = accessor.getValue(record);
     expect(values).toEqual([{ value: "a" }, { value: "b" }]);
+  });
+});
+
+describe("typed accessor methods", () => {
+  const mockList = vi.mocked(listAttributes);
+
+  it("firstText extracts string value", async () => {
+    mockList.mockResolvedValue([mockAttribute("name", "text")]);
+    const schema = await createSchema({
+      target: "objects",
+      identifier: "companies",
+    });
+    const accessor = schema.getAccessorOrThrow("name");
+    const record = { values: { name: [{ value: "Acme" }] } };
+    expect(accessor.firstText(record)).toBe("Acme");
+  });
+
+  it("firstNumber extracts number value", async () => {
+    mockList.mockResolvedValue([mockAttribute("revenue", "number")]);
+    const schema = await createSchema({
+      target: "objects",
+      identifier: "companies",
+    });
+    const accessor = schema.getAccessorOrThrow("revenue");
+    const record = { values: { revenue: [{ value: 42 }] } };
+    expect(accessor.firstNumber(record)).toBe(42);
+  });
+
+  it("firstDate extracts date string", async () => {
+    mockList.mockResolvedValue([mockAttribute("founded", "date")]);
+    const schema = await createSchema({
+      target: "objects",
+      identifier: "companies",
+    });
+    const accessor = schema.getAccessorOrThrow("founded");
+    const record = { values: { founded: [{ value: "2024-01-15" }] } };
+    expect(accessor.firstDate(record)).toBe("2024-01-15");
+  });
+
+  it("firstTimestamp extracts timestamp string", async () => {
+    mockList.mockResolvedValue([mockAttribute("updated_at", "timestamp")]);
+    const schema = await createSchema({
+      target: "objects",
+      identifier: "companies",
+    });
+    const accessor = schema.getAccessorOrThrow("updated_at");
+    const record = {
+      values: { updated_at: [{ value: "2024-01-15T10:30:00Z" }] },
+    };
+    expect(accessor.firstTimestamp(record)).toBe("2024-01-15T10:30:00Z");
+  });
+
+  it("firstCheckbox extracts boolean value", async () => {
+    mockList.mockResolvedValue([mockAttribute("is_active", "checkbox")]);
+    const schema = await createSchema({
+      target: "objects",
+      identifier: "companies",
+    });
+    const accessor = schema.getAccessorOrThrow("is_active");
+    const record = { values: { is_active: [{ value: true }] } };
+    expect(accessor.firstCheckbox(record)).toBe(true);
+  });
+
+  it("firstRating extracts rating number", async () => {
+    mockList.mockResolvedValue([mockAttribute("score", "rating")]);
+    const schema = await createSchema({
+      target: "objects",
+      identifier: "companies",
+    });
+    const accessor = schema.getAccessorOrThrow("score");
+    const record = { values: { score: [{ value: 4 }] } };
+    expect(accessor.firstRating(record)).toBe(4);
+  });
+
+  it("firstCurrencyValue extracts currency_value", async () => {
+    mockList.mockResolvedValue([mockAttribute("arr", "currency")]);
+    const schema = await createSchema({
+      target: "objects",
+      identifier: "companies",
+    });
+    const accessor = schema.getAccessorOrThrow("arr");
+    const record = {
+      values: { arr: [{ currency_value: 100_000, currency_code: "USD" }] },
+    };
+    expect(accessor.firstCurrencyValue(record)).toBe(100_000);
+  });
+
+  it("firstSelectTitle extracts option title", async () => {
+    mockList.mockResolvedValue([mockAttribute("stage", "select")]);
+    const schema = await createSchema({
+      target: "objects",
+      identifier: "companies",
+    });
+    const accessor = schema.getAccessorOrThrow("stage");
+    const record = {
+      values: { stage: [{ option: { title: "Series A" } }] },
+    };
+    expect(accessor.firstSelectTitle(record)).toBe("Series A");
+  });
+
+  it("firstStatusTitle extracts status title", async () => {
+    mockList.mockResolvedValue([mockAttribute("status", "status")]);
+    const schema = await createSchema({
+      target: "objects",
+      identifier: "companies",
+    });
+    const accessor = schema.getAccessorOrThrow("status");
+    const record = {
+      values: { status: [{ status: { title: "Active" } }] },
+    };
+    expect(accessor.firstStatusTitle(record)).toBe("Active");
+  });
+
+  it("firstFullName extracts full_name", async () => {
+    mockList.mockResolvedValue([
+      mockAttribute("contact_name", "personal-name"),
+    ]);
+    const schema = await createSchema({
+      target: "objects",
+      identifier: "people",
+    });
+    const accessor = schema.getAccessorOrThrow("contact_name");
+    const record = {
+      values: {
+        contact_name: [
+          { first_name: "John", last_name: "Doe", full_name: "John Doe" },
+        ],
+      },
+    };
+    expect(accessor.firstFullName(record)).toBe("John Doe");
+  });
+
+  it("firstEmail extracts email_address", async () => {
+    mockList.mockResolvedValue([mockAttribute("email", "email-address")]);
+    const schema = await createSchema({
+      target: "objects",
+      identifier: "people",
+    });
+    const accessor = schema.getAccessorOrThrow("email");
+    const record = {
+      values: {
+        email: [
+          {
+            original_email_address: "john@example.com",
+            email_address: "john@example.com",
+          },
+        ],
+      },
+    };
+    expect(accessor.firstEmail(record)).toBe("john@example.com");
+  });
+
+  it("firstDomain extracts domain", async () => {
+    mockList.mockResolvedValue([mockAttribute("website", "domain")]);
+    const schema = await createSchema({
+      target: "objects",
+      identifier: "companies",
+    });
+    const accessor = schema.getAccessorOrThrow("website");
+    const record = { values: { website: [{ domain: "example.com" }] } };
+    expect(accessor.firstDomain(record)).toBe("example.com");
+  });
+
+  it("firstPhone extracts phone_number", async () => {
+    mockList.mockResolvedValue([mockAttribute("phone", "phone-number")]);
+    const schema = await createSchema({
+      target: "objects",
+      identifier: "people",
+    });
+    const accessor = schema.getAccessorOrThrow("phone");
+    const record = {
+      values: {
+        phone: [
+          {
+            original_phone_number: "+15551234567",
+            phone_number: "+15551234567",
+          },
+        ],
+      },
+    };
+    expect(accessor.firstPhone(record)).toBe("+15551234567");
+  });
+
+  it("firstValueTyped auto-selects extractor by attribute type", async () => {
+    mockList.mockResolvedValue([
+      mockAttribute("name", "text"),
+      mockAttribute("revenue", "number"),
+      mockAttribute("status", "status"),
+    ]);
+    const schema = await createSchema({
+      target: "objects",
+      identifier: "companies",
+    });
+    const record = {
+      values: {
+        name: [{ value: "Acme" }],
+        revenue: [{ value: 42 }],
+        status: [{ status: { title: "Active" } }],
+      },
+    };
+
+    expect(schema.getAccessorOrThrow("name").firstValueTyped(record)).toBe(
+      "Acme",
+    );
+    expect(schema.getAccessorOrThrow("revenue").firstValueTyped(record)).toBe(
+      42,
+    );
+    expect(schema.getAccessorOrThrow("status").firstValueTyped(record)).toBe(
+      "Active",
+    );
+  });
+
+  it("firstValueTyped falls back to getFirstValue for unknown types", async () => {
+    mockList.mockResolvedValue([mockAttribute("custom", "unknown-type")]);
+    const schema = await createSchema({
+      target: "objects",
+      identifier: "companies",
+    });
+    const record = { values: { custom: [{ foo: "bar" }] } };
+    expect(schema.getAccessorOrThrow("custom").firstValueTyped(record)).toEqual(
+      { foo: "bar" },
+    );
+  });
+
+  it("typed accessors return undefined for missing attributes", async () => {
+    mockList.mockResolvedValue([mockAttribute("name", "text")]);
+    const schema = await createSchema({
+      target: "objects",
+      identifier: "companies",
+    });
+    const accessor = schema.getAccessorOrThrow("name");
+    const record = { values: {} };
+    expect(accessor.firstText(record)).toBeUndefined();
+    expect(accessor.firstValueTyped(record)).toBeUndefined();
   });
 });

--- a/test/attio/value-schemas.spec.ts
+++ b/test/attio/value-schemas.spec.ts
@@ -1,0 +1,379 @@
+import { describe, expect, it } from "vitest";
+import {
+  actorReferenceValueSchema,
+  checkboxValueSchema,
+  currencyValueSchema,
+  dateValueSchema,
+  domainValueSchema,
+  emailValueSchema,
+  enrichedSelectValueSchema,
+  enrichedStatusValueSchema,
+  interactionValueSchema,
+  locationValueSchema,
+  numberValueSchema,
+  personalNameValueSchema,
+  phoneValueSchema,
+  ratingValueSchema,
+  recordReferenceValueSchema,
+  selectOptionObjectSchema,
+  selectValueSchema,
+  statusObjectSchema,
+  statusValueSchema,
+  textValueSchema,
+  timestampValueSchema,
+  valueSchemasByType,
+} from "../../src/attio/value-schemas";
+
+describe("scalar value schemas", () => {
+  it("textValueSchema parses valid text", () => {
+    const result = textValueSchema.parse({ value: "hello" });
+    expect(result.value).toBe("hello");
+  });
+
+  it("textValueSchema rejects non-string value", () => {
+    expect(() => textValueSchema.parse({ value: 123 })).toThrow();
+  });
+
+  it("textValueSchema passes through extra fields", () => {
+    const result = textValueSchema.parse({
+      value: "hello",
+      attribute_type: "text",
+      extra: true,
+    });
+    expect(result.value).toBe("hello");
+    expect((result as Record<string, unknown>).extra).toBe(true);
+  });
+
+  it("numberValueSchema parses valid number", () => {
+    const result = numberValueSchema.parse({ value: 42 });
+    expect(result.value).toBe(42);
+  });
+
+  it("numberValueSchema rejects non-number value", () => {
+    expect(() => numberValueSchema.parse({ value: "not a number" })).toThrow();
+  });
+
+  it("checkboxValueSchema parses valid boolean", () => {
+    expect(checkboxValueSchema.parse({ value: true }).value).toBe(true);
+    expect(checkboxValueSchema.parse({ value: false }).value).toBe(false);
+  });
+
+  it("checkboxValueSchema rejects non-boolean value", () => {
+    expect(() => checkboxValueSchema.parse({ value: "yes" })).toThrow();
+  });
+
+  it("dateValueSchema parses valid date string", () => {
+    const result = dateValueSchema.parse({ value: "2024-01-15" });
+    expect(result.value).toBe("2024-01-15");
+  });
+
+  it("dateValueSchema passes through attribute_type", () => {
+    const result = dateValueSchema.parse({
+      value: "2024-01-15",
+      attribute_type: "date",
+    });
+    expect(result.attribute_type).toBe("date");
+  });
+
+  it("timestampValueSchema parses valid timestamp string", () => {
+    const result = timestampValueSchema.parse({
+      value: "2024-01-15T10:30:00Z",
+    });
+    expect(result.value).toBe("2024-01-15T10:30:00Z");
+  });
+
+  it("ratingValueSchema parses valid rating", () => {
+    expect(ratingValueSchema.parse({ value: 0 }).value).toBe(0);
+    expect(ratingValueSchema.parse({ value: 5 }).value).toBe(5);
+    expect(ratingValueSchema.parse({ value: 3 }).value).toBe(3);
+  });
+
+  it("ratingValueSchema rejects out-of-range values", () => {
+    expect(() => ratingValueSchema.parse({ value: -1 })).toThrow();
+    expect(() => ratingValueSchema.parse({ value: 6 })).toThrow();
+  });
+});
+
+describe("complex value schemas", () => {
+  it("currencyValueSchema parses currency with code", () => {
+    const result = currencyValueSchema.parse({
+      currency_value: 50_000,
+      currency_code: "USD",
+    });
+    expect(result.currency_value).toBe(50_000);
+    expect(result.currency_code).toBe("USD");
+  });
+
+  it("currencyValueSchema parses currency without code", () => {
+    const result = currencyValueSchema.parse({ currency_value: 100 });
+    expect(result.currency_value).toBe(100);
+    expect(result.currency_code).toBeUndefined();
+  });
+
+  it("domainValueSchema parses domain", () => {
+    const result = domainValueSchema.parse({
+      domain: "example.com",
+      root_domain: "example.com",
+    });
+    expect(result.domain).toBe("example.com");
+    expect(result.root_domain).toBe("example.com");
+  });
+
+  it("domainValueSchema parses domain without root_domain", () => {
+    const result = domainValueSchema.parse({ domain: "sub.example.com" });
+    expect(result.domain).toBe("sub.example.com");
+  });
+
+  it("emailValueSchema parses email", () => {
+    const result = emailValueSchema.parse({
+      original_email_address: "Test@Example.com",
+      email_address: "test@example.com",
+      email_domain: "example.com",
+      email_root_domain: "example.com",
+      email_local_specifier: "test",
+    });
+    expect(result.email_address).toBe("test@example.com");
+    expect(result.original_email_address).toBe("Test@Example.com");
+  });
+
+  it("emailValueSchema requires original and email address", () => {
+    expect(() =>
+      emailValueSchema.parse({ email_address: "test@example.com" }),
+    ).toThrow();
+  });
+
+  it("phoneValueSchema parses phone number", () => {
+    const result = phoneValueSchema.parse({
+      original_phone_number: "+1 (555) 123-4567",
+      phone_number: "+15551234567",
+      country_code: "US",
+    });
+    expect(result.phone_number).toBe("+15551234567");
+  });
+
+  it("personalNameValueSchema parses name", () => {
+    const result = personalNameValueSchema.parse({
+      first_name: "John",
+      last_name: "Doe",
+      full_name: "John Doe",
+    });
+    expect(result.full_name).toBe("John Doe");
+    expect(result.first_name).toBe("John");
+    expect(result.last_name).toBe("Doe");
+  });
+
+  it("locationValueSchema parses location with nullable fields", () => {
+    const result = locationValueSchema.parse({
+      line_1: "123 Main St",
+      line_2: null,
+      line_3: null,
+      line_4: null,
+      locality: "San Francisco",
+      region: "CA",
+      postcode: "94105",
+      country_code: "US",
+      latitude: "37.7749",
+      longitude: "-122.4194",
+    });
+    expect(result.locality).toBe("San Francisco");
+    expect(result.line_2).toBeNull();
+  });
+});
+
+describe("reference value schemas", () => {
+  it("recordReferenceValueSchema parses record reference", () => {
+    const result = recordReferenceValueSchema.parse({
+      target_object: "companies",
+      target_record_id: "rec_abc123",
+    });
+    expect(result.target_object).toBe("companies");
+    expect(result.target_record_id).toBe("rec_abc123");
+  });
+
+  it("actorReferenceValueSchema parses actor reference", () => {
+    const result = actorReferenceValueSchema.parse({
+      referenced_actor_type: "workspace-member",
+      referenced_actor_id: "mem_abc123",
+    });
+    expect(result.referenced_actor_type).toBe("workspace-member");
+    expect(result.referenced_actor_id).toBe("mem_abc123");
+  });
+
+  it("actorReferenceValueSchema accepts null actor id", () => {
+    const result = actorReferenceValueSchema.parse({
+      referenced_actor_type: "system",
+      referenced_actor_id: null,
+    });
+    expect(result.referenced_actor_id).toBeNull();
+  });
+
+  it("interactionValueSchema parses interaction", () => {
+    const result = interactionValueSchema.parse({
+      interaction_type: "email",
+      interacted_at: "2024-01-15T10:30:00Z",
+      owner_actor: { id: "mem_123", type: "workspace-member" },
+    });
+    expect(result.interaction_type).toBe("email");
+    expect(result.interacted_at).toBe("2024-01-15T10:30:00Z");
+  });
+});
+
+describe("select/status value schemas", () => {
+  it("selectOptionObjectSchema parses option with title", () => {
+    const result = selectOptionObjectSchema.parse({
+      title: "Option A",
+      id: "opt_1",
+    });
+    expect(result.title).toBe("Option A");
+  });
+
+  it("selectValueSchema parses string option", () => {
+    const result = selectValueSchema.parse({ option: "opt_abc" });
+    expect(result.option).toBe("opt_abc");
+  });
+
+  it("selectValueSchema parses enriched option object", () => {
+    const result = selectValueSchema.parse({
+      option: { title: "Active", id: "opt_1" },
+    });
+    expect((result.option as { title: string }).title).toBe("Active");
+  });
+
+  it("enrichedSelectValueSchema requires option object with title", () => {
+    const result = enrichedSelectValueSchema.parse({
+      option: { title: "Active" },
+    });
+    expect(result.option.title).toBe("Active");
+  });
+
+  it("enrichedSelectValueSchema rejects string option", () => {
+    expect(() =>
+      enrichedSelectValueSchema.parse({ option: "opt_abc" }),
+    ).toThrow();
+  });
+
+  it("statusObjectSchema parses status with title", () => {
+    const result = statusObjectSchema.parse({ title: "Open", id: "s_1" });
+    expect(result.title).toBe("Open");
+  });
+
+  it("statusValueSchema parses string status", () => {
+    const result = statusValueSchema.parse({ status: "active" });
+    expect(result.status).toBe("active");
+  });
+
+  it("statusValueSchema parses enriched status object", () => {
+    const result = statusValueSchema.parse({
+      status: { title: "Active", id: "s_1" },
+    });
+    expect((result.status as { title: string }).title).toBe("Active");
+  });
+
+  it("enrichedStatusValueSchema requires status object with title", () => {
+    const result = enrichedStatusValueSchema.parse({
+      status: { title: "Active" },
+    });
+    expect(result.status.title).toBe("Active");
+  });
+
+  it("enrichedStatusValueSchema rejects string status", () => {
+    expect(() =>
+      enrichedStatusValueSchema.parse({ status: "active" }),
+    ).toThrow();
+  });
+});
+
+describe("valueSchemasByType lookup", () => {
+  it("maps all expected attribute types", () => {
+    const expectedTypes = [
+      "text",
+      "number",
+      "checkbox",
+      "date",
+      "timestamp",
+      "rating",
+      "currency",
+      "domain",
+      "email-address",
+      "phone-number",
+      "personal-name",
+      "location",
+      "record-reference",
+      "actor-reference",
+      "interaction",
+      "select",
+      "status",
+    ] as const;
+
+    for (const type of expectedTypes) {
+      expect(valueSchemasByType[type]).toBeDefined();
+    }
+  });
+
+  it("text schema matches textValueSchema", () => {
+    expect(valueSchemasByType.text).toBe(textValueSchema);
+  });
+
+  it("number schema matches numberValueSchema", () => {
+    expect(valueSchemasByType.number).toBe(numberValueSchema);
+  });
+
+  it("each schema in the lookup parses valid data", () => {
+    const validData: Record<string, unknown> = {
+      text: { value: "hello" },
+      number: { value: 42 },
+      checkbox: { value: true },
+      date: { value: "2024-01-01" },
+      timestamp: { value: "2024-01-01T00:00:00Z" },
+      rating: { value: 3 },
+      currency: { currency_value: 100 },
+      domain: { domain: "example.com" },
+      "email-address": {
+        original_email_address: "a@b.com",
+        email_address: "a@b.com",
+      },
+      "phone-number": {
+        original_phone_number: "+1234",
+        phone_number: "+1234",
+      },
+      "personal-name": {
+        first_name: "A",
+        last_name: "B",
+        full_name: "A B",
+      },
+      location: {
+        line_1: null,
+        line_2: null,
+        line_3: null,
+        line_4: null,
+        locality: null,
+        region: null,
+        postcode: null,
+        country_code: null,
+        latitude: null,
+        longitude: null,
+      },
+      "record-reference": {
+        target_object: "people",
+        target_record_id: "r_1",
+      },
+      "actor-reference": {
+        referenced_actor_type: "system",
+        referenced_actor_id: null,
+      },
+      interaction: {
+        interaction_type: "email",
+        interacted_at: "2024-01-01T00:00:00Z",
+        owner_actor: {},
+      },
+      select: { option: "opt_1" },
+      status: { status: "active" },
+    };
+
+    for (const [type, data] of Object.entries(validData)) {
+      const schema =
+        valueSchemasByType[type as keyof typeof valueSchemasByType];
+      expect(schema.safeParse(data).success, `${type} should parse`).toBe(true);
+    }
+  });
+});

--- a/test/attio/values.spec.ts
+++ b/test/attio/values.spec.ts
@@ -2,6 +2,19 @@ import { describe, expect, it } from "vitest";
 import { z } from "zod";
 import { AttioResponseError } from "../../src/attio/errors";
 import {
+  getFirstCheckbox,
+  getFirstCurrencyValue,
+  getFirstDate,
+  getFirstDomain,
+  getFirstEmail,
+  getFirstFullName,
+  getFirstNumber,
+  getFirstPhone,
+  getFirstRating,
+  getFirstSelectTitle,
+  getFirstStatusTitle,
+  getFirstText,
+  getFirstTimestamp,
   getFirstValue,
   getFirstValueSafe,
   getValue,
@@ -129,5 +142,100 @@ describe("getFirstValueSafe", () => {
       expect(result.code).toBe("INVALID_VALUE");
       expect(result.message).toContain("revenue");
     }
+  });
+});
+
+describe("typed primitive getters", () => {
+  const record = {
+    values: {
+      name: [{ value: "Acme" }],
+      revenue: [{ value: 50_000 }],
+      founded: [{ value: "2024-01-15" }],
+      updated_at: [{ value: "2024-01-15T10:30:00Z" }],
+      is_active: [{ value: true }],
+      rating: [{ value: 4 }],
+      arr: [{ currency_value: 100_000, currency_code: "USD" }],
+      stage: [{ option: { title: "Series A" } }],
+      status: [{ status: { title: "Active" } }],
+      contact_name: [
+        { first_name: "John", last_name: "Doe", full_name: "John Doe" },
+      ],
+      email: [
+        {
+          original_email_address: "john@example.com",
+          email_address: "john@example.com",
+        },
+      ],
+      website: [{ domain: "example.com" }],
+      phone: [
+        { original_phone_number: "+15551234567", phone_number: "+15551234567" },
+      ],
+    },
+  };
+
+  it("getFirstText extracts string value", () => {
+    expect(getFirstText(record, "name")).toBe("Acme");
+  });
+
+  it("getFirstNumber extracts number value", () => {
+    expect(getFirstNumber(record, "revenue")).toBe(50_000);
+  });
+
+  it("getFirstDate extracts date string", () => {
+    expect(getFirstDate(record, "founded")).toBe("2024-01-15");
+  });
+
+  it("getFirstTimestamp extracts timestamp string", () => {
+    expect(getFirstTimestamp(record, "updated_at")).toBe(
+      "2024-01-15T10:30:00Z",
+    );
+  });
+
+  it("getFirstCheckbox extracts boolean value", () => {
+    expect(getFirstCheckbox(record, "is_active")).toBe(true);
+  });
+
+  it("getFirstRating extracts rating number", () => {
+    expect(getFirstRating(record, "rating")).toBe(4);
+  });
+
+  it("getFirstCurrencyValue extracts currency_value", () => {
+    expect(getFirstCurrencyValue(record, "arr")).toBe(100_000);
+  });
+
+  it("getFirstSelectTitle extracts option title", () => {
+    expect(getFirstSelectTitle(record, "stage")).toBe("Series A");
+  });
+
+  it("getFirstStatusTitle extracts status title", () => {
+    expect(getFirstStatusTitle(record, "status")).toBe("Active");
+  });
+
+  it("getFirstFullName extracts full_name", () => {
+    expect(getFirstFullName(record, "contact_name")).toBe("John Doe");
+  });
+
+  it("getFirstEmail extracts email_address", () => {
+    expect(getFirstEmail(record, "email")).toBe("john@example.com");
+  });
+
+  it("getFirstDomain extracts domain", () => {
+    expect(getFirstDomain(record, "website")).toBe("example.com");
+  });
+
+  it("getFirstPhone extracts phone_number", () => {
+    expect(getFirstPhone(record, "phone")).toBe("+15551234567");
+  });
+
+  it("returns undefined for missing attribute", () => {
+    expect(getFirstText(record, "missing")).toBeUndefined();
+    expect(getFirstNumber(record, "missing")).toBeUndefined();
+    expect(getFirstCheckbox(record, "missing")).toBeUndefined();
+  });
+
+  it("returns undefined when value shape does not match", () => {
+    expect(getFirstText(record, "revenue")).toBeUndefined();
+    expect(getFirstNumber(record, "name")).toBeUndefined();
+    expect(getFirstCurrencyValue(record, "name")).toBeUndefined();
   });
 });


### PR DESCRIPTION
## **CodeAnt-AI Description**
**Expose value schemas and add safe, typed value accessors**

### What Changed
- Exports reusable Zod schemas for every Attio value type so callers can validate API values without redefining schemas
- Adds non-throwing safe parsers that return a success/error result when value shapes don't match, avoiding exceptions on schema mismatches
- Adds many convenience getters that return the first typed scalar (text, number, date, timestamp, checkbox, rating, currency value, select/status titles, full name, email, domain, phone) and a schema-bound accessor that auto-selects the right extractor by attribute type
- Exposes typed accessors on the schema object so consumers can call attribute.firstText/firstNumber/.../firstValueTyped directly
- Exports the new value schemas so they are available from the package entrypoint

### Impact
`✅ Clearer value parsing errors`
`✅ Fewer runtime exceptions on schema mismatches`
`✅ Faster, simpler access to typed attribute values`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added type-safe value extraction methods for all field types (text, number, dates, checkboxes, ratings, currency, select/status options, personal names, emails, domains, phone numbers, and references)
  * Introduced safe parsing utilities that return results instead of throwing errors
  * Expanded attribute accessor API with per-type methods for direct typed value access

* **Tests**
  * Added comprehensive test coverage for value schemas and extraction utilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->