### PR TITLE
fix: address value schema review feedback

### DIFF
--- a/src/attio/schema.ts
+++ b/src/attio/schema.ts
@@ -81,10 +81,13 @@ interface AttioSchema {
   getAccessorOrThrow: (slug: string) => AttributeAccessor;
 }
 
-const typedExtractors: Record<
-  ValueAttributeType,
-  (record: AttioRecordLike, slug: string) => unknown | undefined
-> = {
+type AttributeType = NonNullable<ZodAttribute["type"]>;
+type TypedExtractor = (
+  record: AttioRecordLike,
+  slug: string,
+) => unknown | undefined;
+
+const typedExtractors = {
   text: getFirstText,
   number: getFirstNumber,
   date: getFirstDate,
@@ -118,6 +121,16 @@ const typedExtractors: Record<
     const result = getFirstValueSafe(record, slug, schema);
     return result.ok ? result.value : undefined;
   },
+} satisfies Record<AttributeType, TypedExtractor> &
+  Record<ValueAttributeType, TypedExtractor>;
+
+const getTypedExtractor = (
+  attributeType: ZodAttribute["type"],
+): TypedExtractor | undefined => {
+  if (attributeType === null) {
+    return;
+  }
+  return typedExtractors[attributeType];
 };
 
 const createAccessor = (attribute: ZodAttribute): AttributeAccessor => {
@@ -143,7 +156,7 @@ const createAccessor = (attribute: ZodAttribute): AttributeAccessor => {
     firstDomain: (record) => getFirstDomain(record, slug),
     firstPhone: (record) => getFirstPhone(record, slug),
     firstValueTyped: (record) => {
-      const extractor = typedExtractors[attribute.type as ValueAttributeType];
+      const extractor = getTypedExtractor(attribute.type);
       if (!extractor) {
         return getFirstValue(record, slug);
       }

--- a/src/attio/value-schemas.ts
+++ b/src/attio/value-schemas.ts
@@ -12,14 +12,17 @@ const checkboxValueSchema = z.object({ value: z.boolean() }).passthrough();
 type CheckboxValue = z.infer<typeof checkboxValueSchema>;
 
 const dateValueSchema = z
-  .object({ value: z.string(), attribute_type: z.literal("date").optional() })
+  .object({
+    value: z.iso.date(),
+    attribute_type: z.literal("date").nullable().optional(),
+  })
   .passthrough();
 type DateValue = z.infer<typeof dateValueSchema>;
 
 const timestampValueSchema = z
   .object({
-    value: z.string(),
-    attribute_type: z.literal("timestamp").optional(),
+    value: z.iso.datetime(),
+    attribute_type: z.literal("timestamp").nullable().optional(),
   })
   .passthrough();
 type TimestampValue = z.infer<typeof timestampValueSchema>;
@@ -97,12 +100,9 @@ type RecordReferenceValue = z.infer<typeof recordReferenceValueSchema>;
 
 const actorReferenceValueSchema = z
   .object({
-    referenced_actor_type: z.enum([
-      "api-token",
-      "workspace-member",
-      "system",
-      "app",
-    ]),
+    referenced_actor_type: z
+      .enum(["api-token", "workspace-member", "system", "app"])
+      .nullable(),
     referenced_actor_id: z.string().nullable(),
   })
   .passthrough();

--- a/src/attio/values.ts
+++ b/src/attio/values.ts
@@ -8,12 +8,12 @@ import {
   dateValueSchema,
   domainValueSchema,
   emailValueSchema,
-  enrichedSelectValueSchema,
-  enrichedStatusValueSchema,
   numberValueSchema,
   personalNameValueSchema,
   phoneValueSchema,
   ratingValueSchema,
+  selectValueSchema,
+  statusValueSchema,
   textValueSchema,
   timestampValueSchema,
 } from "./value-schemas";
@@ -148,9 +148,11 @@ function getFirstValue<T>(
   return values ? values[0] : undefined;
 }
 
+type ValueErrorCode = "INVALID_VALUE";
+
 type ValueResult<T> =
   | { ok: true; value: T }
-  | { ok: false; code: string; message: string };
+  | { ok: false; code: ValueErrorCode; message: string };
 
 const safeParseValues = <T>(
   raw: unknown[],
@@ -261,22 +263,16 @@ const getFirstSelectTitle = (
   record: AttioRecordLike,
   attribute: string,
 ): string | undefined =>
-  extractFirstScalar(
-    record,
-    attribute,
-    enrichedSelectValueSchema,
-    (v) => v.option.title,
+  extractFirstScalar(record, attribute, selectValueSchema, (v) =>
+    typeof v.option === "string" ? v.option : v.option.title,
   );
 
 const getFirstStatusTitle = (
   record: AttioRecordLike,
   attribute: string,
 ): string | undefined =>
-  extractFirstScalar(
-    record,
-    attribute,
-    enrichedStatusValueSchema,
-    (v) => v.status.title,
+  extractFirstScalar(record, attribute, statusValueSchema, (v) =>
+    typeof v.status === "string" ? v.status : v.status.title,
   );
 
 const getFirstFullName = (
@@ -339,6 +335,7 @@ export {
   value,
 };
 export type {
+  ValueErrorCode,
   ValueCurrencyInput,
   ValueFactory,
   ValueInput,

--- a/test/attio/schema.spec.ts
+++ b/test/attio/schema.spec.ts
@@ -1,14 +1,19 @@
 import { describe, expect, it, vi } from "vitest";
 import { z } from "zod";
 import { AttioResponseError } from "../../src/attio/errors";
-import { listAttributes } from "../../src/attio/metadata";
+import { listAttributes, type ZodAttribute } from "../../src/attio/metadata";
 import { createSchema } from "../../src/attio/schema";
 
 vi.mock("../../src/attio/metadata", () => ({
   listAttributes: vi.fn(),
 }));
 
-const mockAttribute = (slug: string, type: string) => ({
+interface MockAttributeInput {
+  slug: ZodAttribute["api_slug"];
+  type: ZodAttribute["type"];
+}
+
+const mockAttribute = ({ slug, type }: MockAttributeInput): ZodAttribute => ({
   id: { workspace_id: "w1", object_id: "o1", attribute_id: `a_${slug}` },
   title: slug,
   description: null,
@@ -300,7 +305,7 @@ describe("typed accessor methods", () => {
   const mockList = vi.mocked(listAttributes);
 
   it("firstText extracts string value", async () => {
-    mockList.mockResolvedValue([mockAttribute("name", "text")]);
+    mockList.mockResolvedValue([mockAttribute({ slug: "name", type: "text" })]);
     const schema = await createSchema({
       target: "objects",
       identifier: "companies",
@@ -311,7 +316,9 @@ describe("typed accessor methods", () => {
   });
 
   it("firstNumber extracts number value", async () => {
-    mockList.mockResolvedValue([mockAttribute("revenue", "number")]);
+    mockList.mockResolvedValue([
+      mockAttribute({ slug: "revenue", type: "number" }),
+    ]);
     const schema = await createSchema({
       target: "objects",
       identifier: "companies",
@@ -322,7 +329,9 @@ describe("typed accessor methods", () => {
   });
 
   it("firstDate extracts date string", async () => {
-    mockList.mockResolvedValue([mockAttribute("founded", "date")]);
+    mockList.mockResolvedValue([
+      mockAttribute({ slug: "founded", type: "date" }),
+    ]);
     const schema = await createSchema({
       target: "objects",
       identifier: "companies",
@@ -333,7 +342,9 @@ describe("typed accessor methods", () => {
   });
 
   it("firstTimestamp extracts timestamp string", async () => {
-    mockList.mockResolvedValue([mockAttribute("updated_at", "timestamp")]);
+    mockList.mockResolvedValue([
+      mockAttribute({ slug: "updated_at", type: "timestamp" }),
+    ]);
     const schema = await createSchema({
       target: "objects",
       identifier: "companies",
@@ -345,8 +356,27 @@ describe("typed accessor methods", () => {
     expect(accessor.firstTimestamp(record)).toBe("2024-01-15T10:30:00Z");
   });
 
+  it("firstTimestamp accepts null attribute_type from API output", async () => {
+    mockList.mockResolvedValue([
+      mockAttribute({ slug: "updated_at", type: "timestamp" }),
+    ]);
+    const schema = await createSchema({
+      target: "objects",
+      identifier: "companies",
+    });
+    const accessor = schema.getAccessorOrThrow("updated_at");
+    const record = {
+      values: {
+        updated_at: [{ value: "2024-01-15T10:30:00Z", attribute_type: null }],
+      },
+    };
+    expect(accessor.firstTimestamp(record)).toBe("2024-01-15T10:30:00Z");
+  });
+
   it("firstCheckbox extracts boolean value", async () => {
-    mockList.mockResolvedValue([mockAttribute("is_active", "checkbox")]);
+    mockList.mockResolvedValue([
+      mockAttribute({ slug: "is_active", type: "checkbox" }),
+    ]);
     const schema = await createSchema({
       target: "objects",
       identifier: "companies",
@@ -357,7 +387,9 @@ describe("typed accessor methods", () => {
   });
 
   it("firstRating extracts rating number", async () => {
-    mockList.mockResolvedValue([mockAttribute("score", "rating")]);
+    mockList.mockResolvedValue([
+      mockAttribute({ slug: "score", type: "rating" }),
+    ]);
     const schema = await createSchema({
       target: "objects",
       identifier: "companies",
@@ -368,7 +400,9 @@ describe("typed accessor methods", () => {
   });
 
   it("firstCurrencyValue extracts currency_value", async () => {
-    mockList.mockResolvedValue([mockAttribute("arr", "currency")]);
+    mockList.mockResolvedValue([
+      mockAttribute({ slug: "arr", type: "currency" }),
+    ]);
     const schema = await createSchema({
       target: "objects",
       identifier: "companies",
@@ -381,7 +415,9 @@ describe("typed accessor methods", () => {
   });
 
   it("firstSelectTitle extracts option title", async () => {
-    mockList.mockResolvedValue([mockAttribute("stage", "select")]);
+    mockList.mockResolvedValue([
+      mockAttribute({ slug: "stage", type: "select" }),
+    ]);
     const schema = await createSchema({
       target: "objects",
       identifier: "companies",
@@ -393,8 +429,25 @@ describe("typed accessor methods", () => {
     expect(accessor.firstSelectTitle(record)).toBe("Series A");
   });
 
+  it("firstSelectTitle falls back to raw option string", async () => {
+    mockList.mockResolvedValue([
+      mockAttribute({ slug: "stage", type: "select" }),
+    ]);
+    const schema = await createSchema({
+      target: "objects",
+      identifier: "companies",
+    });
+    const accessor = schema.getAccessorOrThrow("stage");
+    const record = {
+      values: { stage: [{ option: "opt_abc123" }] },
+    };
+    expect(accessor.firstSelectTitle(record)).toBe("opt_abc123");
+  });
+
   it("firstStatusTitle extracts status title", async () => {
-    mockList.mockResolvedValue([mockAttribute("status", "status")]);
+    mockList.mockResolvedValue([
+      mockAttribute({ slug: "status", type: "status" }),
+    ]);
     const schema = await createSchema({
       target: "objects",
       identifier: "companies",
@@ -406,9 +459,24 @@ describe("typed accessor methods", () => {
     expect(accessor.firstStatusTitle(record)).toBe("Active");
   });
 
+  it("firstStatusTitle falls back to raw status string", async () => {
+    mockList.mockResolvedValue([
+      mockAttribute({ slug: "status", type: "status" }),
+    ]);
+    const schema = await createSchema({
+      target: "objects",
+      identifier: "companies",
+    });
+    const accessor = schema.getAccessorOrThrow("status");
+    const record = {
+      values: { status: [{ status: "sta_abc123" }] },
+    };
+    expect(accessor.firstStatusTitle(record)).toBe("sta_abc123");
+  });
+
   it("firstFullName extracts full_name", async () => {
     mockList.mockResolvedValue([
-      mockAttribute("contact_name", "personal-name"),
+      mockAttribute({ slug: "contact_name", type: "personal-name" }),
     ]);
     const schema = await createSchema({
       target: "objects",
@@ -426,7 +494,9 @@ describe("typed accessor methods", () => {
   });
 
   it("firstEmail extracts email_address", async () => {
-    mockList.mockResolvedValue([mockAttribute("email", "email-address")]);
+    mockList.mockResolvedValue([
+      mockAttribute({ slug: "email", type: "email-address" }),
+    ]);
     const schema = await createSchema({
       target: "objects",
       identifier: "people",
@@ -446,7 +516,9 @@ describe("typed accessor methods", () => {
   });
 
   it("firstDomain extracts domain", async () => {
-    mockList.mockResolvedValue([mockAttribute("website", "domain")]);
+    mockList.mockResolvedValue([
+      mockAttribute({ slug: "website", type: "domain" }),
+    ]);
     const schema = await createSchema({
       target: "objects",
       identifier: "companies",
@@ -457,7 +529,9 @@ describe("typed accessor methods", () => {
   });
 
   it("firstPhone extracts phone_number", async () => {
-    mockList.mockResolvedValue([mockAttribute("phone", "phone-number")]);
+    mockList.mockResolvedValue([
+      mockAttribute({ slug: "phone", type: "phone-number" }),
+    ]);
     const schema = await createSchema({
       target: "objects",
       identifier: "people",
@@ -478,9 +552,9 @@ describe("typed accessor methods", () => {
 
   it("firstValueTyped auto-selects extractor by attribute type", async () => {
     mockList.mockResolvedValue([
-      mockAttribute("name", "text"),
-      mockAttribute("revenue", "number"),
-      mockAttribute("status", "status"),
+      mockAttribute({ slug: "name", type: "text" }),
+      mockAttribute({ slug: "revenue", type: "number" }),
+      mockAttribute({ slug: "status", type: "status" }),
     ]);
     const schema = await createSchema({
       target: "objects",
@@ -505,8 +579,75 @@ describe("typed accessor methods", () => {
     );
   });
 
-  it("firstValueTyped falls back to getFirstValue for unknown types", async () => {
-    mockList.mockResolvedValue([mockAttribute("custom", "unknown-type")]);
+  it("firstValueTyped returns structured object values", async () => {
+    mockList.mockResolvedValue([
+      mockAttribute({ slug: "owner", type: "actor-reference" }),
+      mockAttribute({ slug: "company", type: "record-reference" }),
+      mockAttribute({ slug: "address", type: "location" }),
+      mockAttribute({ slug: "last_interaction", type: "interaction" }),
+    ]);
+    const schema = await createSchema({
+      target: "objects",
+      identifier: "companies",
+    });
+    const record = {
+      values: {
+        owner: [
+          {
+            referenced_actor_type: null,
+            referenced_actor_id: "mem_abc123",
+          },
+        ],
+        company: [
+          {
+            target_object: "companies",
+            target_record_id: "rec_abc123",
+          },
+        ],
+        address: [
+          {
+            line_1: "123 Main St",
+            line_2: null,
+            line_3: null,
+            line_4: null,
+            locality: "San Francisco",
+            region: "CA",
+            postcode: "94105",
+            country_code: "US",
+            latitude: "37.7749",
+            longitude: "-122.4194",
+          },
+        ],
+        last_interaction: [
+          {
+            interaction_type: "email",
+            interacted_at: "2024-01-15T10:30:00Z",
+            owner_actor: {},
+          },
+        ],
+      },
+    };
+
+    expect(schema.getAccessorOrThrow("owner").firstValueTyped(record)).toEqual({
+      referenced_actor_type: null,
+      referenced_actor_id: "mem_abc123",
+    });
+    expect(
+      schema.getAccessorOrThrow("company").firstValueTyped(record),
+    ).toEqual({
+      target_object: "companies",
+      target_record_id: "rec_abc123",
+    });
+    expect(
+      schema.getAccessorOrThrow("address").firstValueTyped(record),
+    ).toEqual(expect.objectContaining({ locality: "San Francisco" }));
+    expect(
+      schema.getAccessorOrThrow("last_interaction").firstValueTyped(record),
+    ).toEqual(expect.objectContaining({ interaction_type: "email" }));
+  });
+
+  it("firstValueTyped falls back to getFirstValue for null attribute type", async () => {
+    mockList.mockResolvedValue([mockAttribute({ slug: "custom", type: null })]);
     const schema = await createSchema({
       target: "objects",
       identifier: "companies",
@@ -518,7 +659,7 @@ describe("typed accessor methods", () => {
   });
 
   it("typed accessors return undefined for missing attributes", async () => {
-    mockList.mockResolvedValue([mockAttribute("name", "text")]);
+    mockList.mockResolvedValue([mockAttribute({ slug: "name", type: "text" })]);
     const schema = await createSchema({
       target: "objects",
       identifier: "companies",

--- a/test/attio/value-schemas.spec.ts
+++ b/test/attio/value-schemas.spec.ts
@@ -21,6 +21,7 @@ import {
   statusValueSchema,
   textValueSchema,
   timestampValueSchema,
+  type ValueAttributeType,
   valueSchemasByType,
 } from "../../src/attio/value-schemas";
 
@@ -41,7 +42,11 @@ describe("scalar value schemas", () => {
       extra: true,
     });
     expect(result.value).toBe("hello");
-    expect((result as Record<string, unknown>).extra).toBe(true);
+    expect(result).toMatchObject({
+      value: "hello",
+      attribute_type: "text",
+      extra: true,
+    });
   });
 
   it("numberValueSchema parses valid number", () => {
@@ -75,11 +80,37 @@ describe("scalar value schemas", () => {
     expect(result.attribute_type).toBe("date");
   });
 
+  it("dateValueSchema accepts null attribute_type from API output", () => {
+    const result = dateValueSchema.parse({
+      value: "2024-01-15",
+      attribute_type: null,
+    });
+    expect(result.attribute_type).toBeNull();
+  });
+
+  it("dateValueSchema rejects non-date strings", () => {
+    expect(() =>
+      dateValueSchema.parse({ value: "January 15, 2024" }),
+    ).toThrow();
+  });
+
   it("timestampValueSchema parses valid timestamp string", () => {
     const result = timestampValueSchema.parse({
       value: "2024-01-15T10:30:00Z",
     });
     expect(result.value).toBe("2024-01-15T10:30:00Z");
+  });
+
+  it("timestampValueSchema accepts null attribute_type from API output", () => {
+    const result = timestampValueSchema.parse({
+      value: "2024-01-15T10:30:00Z",
+      attribute_type: null,
+    });
+    expect(result.attribute_type).toBeNull();
+  });
+
+  it("timestampValueSchema rejects non-datetime strings", () => {
+    expect(() => timestampValueSchema.parse({ value: "2024-01-15" })).toThrow();
   });
 
   it("ratingValueSchema parses valid rating", () => {
@@ -207,6 +238,18 @@ describe("reference value schemas", () => {
     expect(result.referenced_actor_id).toBeNull();
   });
 
+  it("actorReferenceValueSchema accepts null actor type from API output", () => {
+    const result = actorReferenceValueSchema.parse({
+      referenced_actor_type: null,
+      referenced_actor_id: "mem_abc123",
+      attribute_type: "actor-reference",
+    });
+    expect(result).toMatchObject({
+      referenced_actor_type: null,
+      referenced_actor_id: "mem_abc123",
+    });
+  });
+
   it("interactionValueSchema parses interaction", () => {
     const result = interactionValueSchema.parse({
       interaction_type: "email",
@@ -236,7 +279,7 @@ describe("select/status value schemas", () => {
     const result = selectValueSchema.parse({
       option: { title: "Active", id: "opt_1" },
     });
-    expect((result.option as { title: string }).title).toBe("Active");
+    expect(result.option).toMatchObject({ title: "Active" });
   });
 
   it("enrichedSelectValueSchema requires option object with title", () => {
@@ -266,7 +309,7 @@ describe("select/status value schemas", () => {
     const result = statusValueSchema.parse({
       status: { title: "Active", id: "s_1" },
     });
-    expect((result.status as { title: string }).title).toBe("Active");
+    expect(result.status).toMatchObject({ title: "Active" });
   });
 
   it("enrichedStatusValueSchema requires status object with title", () => {
@@ -284,27 +327,27 @@ describe("select/status value schemas", () => {
 });
 
 describe("valueSchemasByType lookup", () => {
-  it("maps all expected attribute types", () => {
-    const expectedTypes = [
-      "text",
-      "number",
-      "checkbox",
-      "date",
-      "timestamp",
-      "rating",
-      "currency",
-      "domain",
-      "email-address",
-      "phone-number",
-      "personal-name",
-      "location",
-      "record-reference",
-      "actor-reference",
-      "interaction",
-      "select",
-      "status",
-    ] as const;
+  const expectedTypes: ValueAttributeType[] = [
+    "text",
+    "number",
+    "checkbox",
+    "date",
+    "timestamp",
+    "rating",
+    "currency",
+    "domain",
+    "email-address",
+    "phone-number",
+    "personal-name",
+    "location",
+    "record-reference",
+    "actor-reference",
+    "interaction",
+    "select",
+    "status",
+  ];
 
+  it("maps all expected attribute types", () => {
     for (const type of expectedTypes) {
       expect(valueSchemasByType[type]).toBeDefined();
     }
@@ -319,12 +362,12 @@ describe("valueSchemasByType lookup", () => {
   });
 
   it("each schema in the lookup parses valid data", () => {
-    const validData: Record<string, unknown> = {
+    const validData: Record<ValueAttributeType, unknown> = {
       text: { value: "hello" },
       number: { value: 42 },
       checkbox: { value: true },
       date: { value: "2024-01-01" },
-      timestamp: { value: "2024-01-01T00:00:00Z" },
+      timestamp: { value: "2024-01-01T00:00:00Z", attribute_type: null },
       rating: { value: 3 },
       currency: { currency_value: 100 },
       domain: { domain: "example.com" },
@@ -358,7 +401,7 @@ describe("valueSchemasByType lookup", () => {
         target_record_id: "r_1",
       },
       "actor-reference": {
-        referenced_actor_type: "system",
+        referenced_actor_type: null,
         referenced_actor_id: null,
       },
       interaction: {
@@ -370,10 +413,12 @@ describe("valueSchemasByType lookup", () => {
       status: { status: "active" },
     };
 
-    for (const [type, data] of Object.entries(validData)) {
-      const schema =
-        valueSchemasByType[type as keyof typeof valueSchemasByType];
-      expect(schema.safeParse(data).success, `${type} should parse`).toBe(true);
+    for (const type of expectedTypes) {
+      const schema = valueSchemasByType[type];
+      expect(
+        schema.safeParse(validData[type]).success,
+        `${type} should parse`,
+      ).toBe(true);
     }
   });
 });

--- a/test/attio/values.spec.ts
+++ b/test/attio/values.spec.ts
@@ -156,7 +156,9 @@ describe("typed primitive getters", () => {
       rating: [{ value: 4 }],
       arr: [{ currency_value: 100_000, currency_code: "USD" }],
       stage: [{ option: { title: "Series A" } }],
+      stage_id: [{ option: "opt_abc123" }],
       status: [{ status: { title: "Active" } }],
+      status_id: [{ status: "sta_abc123" }],
       contact_name: [
         { first_name: "John", last_name: "Doe", full_name: "John Doe" },
       ],
@@ -207,8 +209,16 @@ describe("typed primitive getters", () => {
     expect(getFirstSelectTitle(record, "stage")).toBe("Series A");
   });
 
+  it("getFirstSelectTitle falls back to raw option string", () => {
+    expect(getFirstSelectTitle(record, "stage_id")).toBe("opt_abc123");
+  });
+
   it("getFirstStatusTitle extracts status title", () => {
     expect(getFirstStatusTitle(record, "status")).toBe("Active");
+  });
+
+  it("getFirstStatusTitle falls back to raw status string", () => {
+    expect(getFirstStatusTitle(record, "status_id")).toBe("sta_abc123");
   });
 
   it("getFirstFullName extracts full_name", () => {


### PR DESCRIPTION
Align handwritten value schemas with API output nullability.

Tighten date and timestamp parsing.

Remove the typed accessor cast.

Preserve raw select/status string fallback values.

Add regression coverage for generated-contract nullable fields.

Cover object typed accessors and safer test typing.

Model: GPT-5 (reasoning: medium)

Thread: 019e223b-02c6-7033-be26-da73a08d7975

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced handling of null attribute types in date and timestamp schemas
  * Added support for string values in select and status field fallbacks
  * Improved type safety for error handling with specific error codes

* **Tests**
  * Extended coverage for edge cases with null attribute types and string-based values

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hbmartin/attio-ts-sdk/pull/146)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix value schemas to accept null attribute types and enforce ISO date/datetime formats
> - Changes `dateValueSchema` and `timestampValueSchema` to use `z.iso.date()` and `z.iso.datetime()` respectively, rejecting non-ISO strings.
> - Allows `attribute_type` to be `null` in date, timestamp, and actor-reference schemas, and handles null actor `referenced_actor_type`.
> - Adds `getTypedExtractor` helper in [schema.ts](https://github.com/hbmartin/attio-ts-sdk/pull/146/files#diff-289e7ed0a1f263d6270fed07a4b17df4391dbef4702712c647a04b796818d788) to explicitly handle null attribute types, replacing a cast-based index into `typedExtractors`.
> - Updates `getFirstSelectTitle` and `getFirstStatusTitle` in [values.ts](https://github.com/hbmartin/attio-ts-sdk/pull/146/files#diff-6619b0c228f7ba3f812c3b3e2ae62bdd0ce5bc2aac55edd052fc6310a55bd508) to fall back to raw string IDs when values are not enriched objects.
> - Behavioral Change: date and timestamp values that are not valid ISO strings now fail schema parsing.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6e04cf2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->