### PR TITLE
feat: improve attio sdk ergonomics

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,17 @@ const listId = createListId('sales-pipeline');
 
 The factory validates the input and throws if the string is empty.
 
+Every branded SDK identifier also has an exported Zod schema when you need to parse strings at your own boundaries:
+
+```typescript
+import { listIdSchema, recordIdSchema } from 'attio-ts-sdk';
+
+const listId = listIdSchema.parse(formData.get('listId'));
+const recordId = recordIdSchema.parse(params.recordId);
+```
+
+Schemas are exported for records (`recordIdSchema`, `recordObjectIdSchema`, `matchingAttributeSchema`), lists (`listIdSchema`, `entryIdSchema`, `parentObjectIdSchema`, `parentRecordIdSchema`), objects (`objectSlugSchema`, `objectApiSlugSchema`, `objectNounSchema`), notes, tasks, and workspace members.
+
 #### Strongly Typed Filters
 
 Filter types are now strongly typed instead of `Record<string, unknown>`. If you were passing arbitrary objects as filters, you may need to adjust your code to match the `AttioFilter` type.
@@ -148,6 +159,14 @@ filters.path(
   [['companies', 'primary_contact']],
   { email: { $contains: '@acme.com' } }
 )
+
+// List-entry relationship helpers
+filters.parentRecordId({
+  list: 'hiring-pipeline',
+  object: 'people',
+  recordId: 'rec_123',
+})
+filters.listStatus({ attribute: 'stage', status: 'Interview' })
 ```
 
 #### AbortSignal Support
@@ -272,26 +291,28 @@ console.log(objects);
 `createAttioSdk` builds on top of the convenience layer and the generated endpoints to provide a single, namespaced object you can pass around your application. It binds the client once so you don't repeat `{ client }` on every call, and groups operations by resource.
 
 ```typescript
-import { createAttioSdk } from 'attio-ts-sdk';
+import { createAttioSdk, filters } from 'attio-ts-sdk';
 
 const sdk = createAttioSdk({ apiKey: process.env.ATTIO_API_KEY });
 ```
+
+`createAttioSdk` accepts the same flat client config as `createAttioClient`. You can also pass `{ config: { apiKey } }` or an existing `{ client }`.
 
 The returned `sdk` object exposes these namespaces:
 
 | Namespace | Methods |
 | --- | --- |
 | `sdk.objects` | `list`, `get`, `create`, `update` |
-| `sdk.records` | `create`, `update`, `upsert`, `get`, `delete`, `query` |
+| `sdk.records` | `create`, `update`, `upsert`, `get`, `getMany`, `delete`, `query` |
 | `sdk.lists` | `list`, `get`, `queryEntries`, `addEntry`, `updateEntry`, `removeEntry` |
-| `sdk.metadata` | `listAttributes`, `getAttribute`, `getAttributeOptions`, `getAttributeStatuses`, `schema` |
+| `sdk.metadata` | `listAttributes`, `findAttribute`, `getAttribute`, `getAttributeOptions`, `getAttributeStatuses`, `listAllowedValues`, `schema` |
 
 The underlying `AttioClient` is also available as `sdk.client` when you need to drop down to the generated endpoints.
 
 ```typescript
 const companies = await sdk.records.query({
   object: 'companies',
-  filter: { attribute: 'name', value: 'Acme' },
+  filter: filters.contains('name', 'Acme'),
 });
 
 const attributes = await sdk.metadata.listAttributes({
@@ -342,10 +363,17 @@ import { value } from 'attio-ts-sdk';
 | Helper | Signature | Description |
 | --- | --- | --- |
 | `value.string` | `(value: string) => ValueInput[]` | Non-empty string field. |
+| `value.text` | `(value: string) => ValueInput[]` | Alias for raw text fields. |
 | `value.number` | `(value: number) => ValueInput[]` | Finite numeric field. |
 | `value.boolean` | `(value: boolean) => ValueInput[]` | Boolean field. |
 | `value.domain` | `(value: string) => ValueInput[]` | Domain field (non-empty string). |
 | `value.email` | `(value: string) => ValueInput[]` | Email field (validated format). |
+| `value.phone` | `(value: string, countryCode?: string) => ValueInput[]` | Phone field, with optional ISO country code. |
+| `value.personalName` | `(input: ValuePersonalNameInput) => ValueInput[]` | Personal name values. |
+| `value.status` | `(value: string) => ValueInput[]` | Status by title or ID. |
+| `value.select` | `(value: string) => ValueInput[]` | Select option by title or ID. |
+| `value.recordReference` | `(input: ValueRecordReferenceInput) => ValueInput[]` | Record-reference value. |
+| `value.location` | `(input: ValueLocationInput) => ValueInput[]` | Location value with missing fields filled as `null`. |
 | `value.currency` | `(value: number, currencyCode?: string) => ValueInput[]` | Currency field. `currencyCode` is an optional ISO 4217 code (e.g. `"USD"`). |
 
 ```typescript
@@ -353,9 +381,12 @@ const values = {
   name: value.string('Acme Corp'),
   domains: value.domain('acme.com'),
   contact_email: value.email('hello@acme.com'),
+  phone_numbers: value.phone('+15551234567'),
+  status: value.status('Customer'),
   employee_count: value.number(150),
   is_customer: value.boolean(true),
   annual_revenue: value.currency(50000, 'USD'),
+  headquarters: value.location({ locality: 'San Francisco', countryCode: 'US' }),
 };
 
 await sdk.records.create({ object: 'companies', values });
@@ -378,6 +409,22 @@ import { z } from 'zod';
 const nameSchema = z.object({ value: z.string() });
 const typedName = getFirstValue(company, 'name', { schema: nameSchema });
 //    ^? { value: string } | undefined
+```
+
+Common value readers are exported for response shapes you usually do not want to parse by hand:
+
+```typescript
+import {
+  getFirstEmail,
+  getFirstPhone,
+  getRecordReferenceIds,
+  getSelectTitles,
+} from 'attio-ts-sdk';
+
+const email = getFirstEmail(person, 'email_addresses');
+const phone = getFirstPhone(person, 'phone_numbers');
+const segmentTitles = getSelectTitles(company, 'segments');
+const companyIds = getRecordReferenceIds(person, 'company');
 ```
 
 ### Schema Helpers
@@ -436,7 +483,7 @@ error.suggestions  // fuzzy-match suggestions for value mismatches (see below)
 #### Catching errors from the convenience layer
 
 ```typescript
-import { createAttioClient, createRecord, AttioError } from 'attio-ts-sdk';
+import { createAttioClient, createRecord, isAttioError } from 'attio-ts-sdk';
 
 const client = createAttioClient({ apiKey: process.env.ATTIO_API_KEY });
 
@@ -447,13 +494,26 @@ try {
     values: { stage: [{ value: 'Prospectt' }] },
   });
 } catch (err) {
-  if (err instanceof AttioError) {
+  if (isAttioError(err)) {
     console.log(err.status, err.code, err.requestId, err.suggestions);
   } else {
     // Re-throw if it's not an error we specifically handle
     throw err;
   }
 }
+```
+
+Stable helpers are available when `instanceof` is unreliable across bundled or test environments:
+
+```typescript
+import {
+  getAttioErrorStatus,
+  isAttioNotFound,
+  isRetryableAttioError,
+} from 'attio-ts-sdk';
+
+if (isAttioNotFound(err)) return undefined;
+if (isRetryableAttioError(err)) console.log(getAttioErrorStatus(err));
 ```
 
 #### Smart suggestions for value mismatches
@@ -516,7 +576,7 @@ The SDK provides multiple approaches to pagination, from simple convenience opti
 The simplest way to paginate record queries is using the `paginate` option on `queryRecords`:
 
 ```typescript
-import { createAttioClient, queryRecords } from 'attio-ts-sdk';
+import { createAttioClient, filters, queryRecords } from 'attio-ts-sdk';
 
 const client = createAttioClient({ apiKey: process.env.ATTIO_API_KEY });
 
@@ -524,7 +584,7 @@ const client = createAttioClient({ apiKey: process.env.ATTIO_API_KEY });
 const allCompanies = await queryRecords({
   client,
   object: 'companies',
-  filter: { attribute: 'name', value: 'Acme' },
+  filter: filters.contains('name', 'Acme'),
   sorts: [{ attribute: 'created_at', direction: 'desc' }],
   paginate: true,
   maxItems: 10000,  // Optional: limit total items
@@ -542,6 +602,19 @@ for await (const company of queryRecords({
 
 The same pattern works with `queryListEntries` / `sdk.lists.queryEntries`.
 
+#### Fetching many records by ID
+
+Use `getManyRecords` or `sdk.records.getMany` when you already have record IDs. The helper chunks `$in` queries, runs them with bounded concurrency, and can preserve input order.
+
+```typescript
+const companies = await sdk.records.getMany({
+  object: 'companies',
+  recordIds: ['rec_1', 'rec_2', 'rec_3'],
+  preserveOrder: true,
+  notFound: 'throw',
+});
+```
+
 #### Using low-level pagination helpers
 
 For more control or when working directly with generated endpoints, use `paginateOffset` (offset-based) or `paginate` (cursor-based):
@@ -558,6 +631,7 @@ Both helpers automatically extract items and pagination metadata from raw API re
 ```typescript
 import {
   createAttioClient,
+  filters,
   paginateOffset,
   postV2ObjectsByObjectRecordsQuery,
 } from 'attio-ts-sdk';
@@ -572,7 +646,7 @@ const allCompanies = await paginateOffset(async (offset, limit) => {
     body: {
       offset,
       limit,
-      filter: { attribute: 'name', value: 'Acme' },
+      filter: filters.contains('name', 'Acme'),
       sorts: [{ attribute: 'created_at', direction: 'desc' }],
     },
   });
@@ -582,7 +656,7 @@ const allCompanies = await paginateOffset(async (offset, limit) => {
 #### Paginating list entry queries with `paginateOffset`
 
 ```typescript
-import { paginateOffset, postV2ListsByListEntriesQuery } from 'attio-ts-sdk';
+import { filters, paginateOffset, postV2ListsByListEntriesQuery } from 'attio-ts-sdk';
 
 const allEntries = await paginateOffset(async (offset, limit) => {
   return postV2ListsByListEntriesQuery({
@@ -591,7 +665,7 @@ const allEntries = await paginateOffset(async (offset, limit) => {
     body: {
       offset,
       limit,
-      filter: { attribute: 'stage', value: 'negotiation' },
+      filter: filters.listStatus({ attribute: 'stage', status: 'negotiation' }),
     },
   });
 });
@@ -788,7 +862,12 @@ Note: `createAttioClient` always creates a new client instance. Use `getAttioCli
 ### Metadata Helpers
 
 ```typescript
-import { createAttioClient, getAttributeOptions } from 'attio-ts-sdk';
+import {
+  createAttioClient,
+  findAttribute,
+  getAttributeOptions,
+  listAllowedValues,
+} from 'attio-ts-sdk';
 
 const client = createAttioClient({ apiKey: process.env.ATTIO_API_KEY });
 
@@ -798,6 +877,22 @@ const options = await getAttributeOptions({
   identifier: 'companies',
   attribute: 'stage',
 });
+
+const statusAttribute = await findAttribute({
+  client,
+  target: 'objects',
+  identifier: 'companies',
+  type: 'status',
+  title: 'Stage',
+});
+
+const allowedValues = await listAllowedValues({
+  client,
+  target: 'objects',
+  identifier: 'companies',
+  attribute: 'stage',
+});
+// [{ id, title, archived }]
 ```
 
 ### Working with Records

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -152,14 +152,10 @@
         "noNestedPromises": "error",
         "noContinue": "error",
         "noTernary": "off",
-        "noDeprecatedImports": "error",
-        "noDuplicateDependencies": "error",
         "noDuplicatedSpreadProps": "error",
-        "noEmptySource": "error",
         "noEqualsToNull": "error",
         "noFloatingPromises": "error",
         "noForIn": "error",
-        "noImportCycles": "error",
         "noIncrementDecrement": "error",
         "noMisusedPromises": "error",
         "noMultiAssign": "error",
@@ -171,16 +167,10 @@
         "noSyncScripts": "error",
         "noUndeclaredEnvVars": "error",
         "noUnnecessaryConditions": "error",
-        "noUnusedExpressions": "error",
-        "noUselessCatchBinding": "error",
-        "noUselessUndefined": "error",
         "useArraySortCompare": "error",
-        "useConsistentArrowReturn": "error",
-        "useDeprecatedDate": "error",
         "useDestructuring": "error",
         "useExhaustiveSwitchCases": "error",
         "useFind": "error",
-        "useMaxParams": "error",
         "useRegexpExec": "error",
         "useRequiredScripts": "error",
         "useSortedClasses": "error",
@@ -206,14 +196,12 @@
         },
         "noFloatingClasses": "error",
         "noHexColors": "error",
-        "noJsxLiterals": "error",
         "noJsxPropsBind": "error",
         "noLeakedRender": "error",
         "noRedundantDefaultExport": "error",
         "noRootType": "error",
         "noScriptUrl": "error",
         "noUnknownAttribute": "error",
-        "noUnresolvedImports": "error",
         "useAwaitThenable": "off",
         "useConsistentEnumValueType": "error",
         "useConsistentGraphqlDescriptions": "error",
@@ -467,7 +455,6 @@
           },
           "nursery": {
             "noIncrementDecrement": "off",
-            "noUnresolvedImports": "off",
             "noExcessiveLinesPerFile": "off"
           }
         }
@@ -497,6 +484,20 @@
           },
           "style": {
             "noProcessEnv": "off"
+          }
+        }
+      }
+    },
+    {
+      "includes": [
+        "src/attio/pagination.ts",
+        "src/attio/records.ts",
+        "src/attio/values.ts"
+      ],
+      "linter": {
+        "rules": {
+          "nursery": {
+            "noExcessiveLinesPerFile": "off"
           }
         }
       }

--- a/src/attio/batch.ts
+++ b/src/attio/batch.ts
@@ -199,5 +199,5 @@ const runBatch = <T>(
   });
 };
 
-export type { BatchItemRunParams, BatchItem, BatchResult, BatchOptions };
+export type { BatchItem, BatchItemRunParams, BatchOptions, BatchResult };
 export { runBatch };

--- a/src/attio/cache.ts
+++ b/src/attio/cache.ts
@@ -356,15 +356,15 @@ export type {
   TtlCacheOptions,
 };
 export {
-  DEFAULT_METADATA_CACHE_MAX_ENTRIES,
-  DEFAULT_METADATA_CACHE_TTL_MS,
-  TtlCache,
+  clearClientCache,
+  clearMetadataCacheRegistry,
+  createAttioCacheManager,
   createTtlCache,
   createTtlCacheAdapter,
-  createAttioCacheManager,
-  clearMetadataCacheRegistry,
+  DEFAULT_METADATA_CACHE_MAX_ENTRIES,
+  DEFAULT_METADATA_CACHE_TTL_MS,
   getCachedClient,
-  setCachedClient,
-  clearClientCache,
   hashToken,
+  setCachedClient,
+  TtlCache,
 };

--- a/src/attio/config.ts
+++ b/src/attio/config.ts
@@ -66,8 +66,8 @@ export {
   DEFAULT_BASE_URL,
   getEnvValue,
   normalizeBaseUrl,
-  resolveBaseUrl,
   resolveAuthToken,
+  resolveBaseUrl,
   resolveResponseStyle,
   resolveThrowOnError,
 };

--- a/src/attio/error-enhancer.ts
+++ b/src/attio/error-enhancer.ts
@@ -125,4 +125,4 @@ const enhanceAttioError = (error: AttioError): AttioError => {
 };
 
 export type { AttioValueSuggestion };
-export { getKnownFieldValues, updateKnownFieldValues, enhanceAttioError };
+export { enhanceAttioError, getKnownFieldValues, updateKnownFieldValues };

--- a/src/attio/errors.ts
+++ b/src/attio/errors.ts
@@ -1,4 +1,5 @@
 // biome-ignore-all lint/security/noSecrets: false report
+import { z } from "zod";
 import { enhanceAttioError } from "./error-enhancer";
 
 interface AttioErrorDetails {
@@ -167,6 +168,73 @@ const extractDetails = (error: unknown): AttioErrorDetails => {
   };
 };
 
+const attioErrorInfoSchema = z
+  .object({
+    name: z.string().optional(),
+    message: z.string().optional(),
+    code: z.string().optional(),
+    type: z.string().optional(),
+    status: z.number().optional(),
+    status_code: z.number().optional(),
+    isApiError: z.boolean().optional(),
+    isNetworkError: z.boolean().optional(),
+    retryAfterMs: z.number().optional(),
+    response: z
+      .object({
+        status: z.number().optional(),
+      })
+      .passthrough()
+      .optional(),
+  })
+  .passthrough();
+
+type AttioErrorInfo = z.infer<typeof attioErrorInfoSchema>;
+
+const RETRYABLE_ATTIO_STATUS_CODES = [408, 429, 500, 502, 503, 504];
+
+const parseAttioErrorInfo = (error: unknown): AttioErrorInfo | undefined => {
+  const parsed = attioErrorInfoSchema.safeParse(error);
+  return parsed.success ? parsed.data : undefined;
+};
+
+const getAttioErrorStatus = (error: unknown): number | undefined => {
+  if (error instanceof AttioError) {
+    return error.response?.status ?? error.status;
+  }
+
+  const info = parseAttioErrorInfo(error);
+  return info?.response?.status ?? info?.status ?? info?.status_code;
+};
+
+const isAttioError = (error: unknown): error is AttioError => {
+  if (error instanceof AttioError) {
+    return true;
+  }
+
+  const info = parseAttioErrorInfo(error);
+  if (!info) {
+    return false;
+  }
+
+  return Boolean(
+    (info.name?.startsWith("Attio") && info.name.endsWith("Error")) ||
+      info.isApiError ||
+      info.isNetworkError,
+  );
+};
+
+const isAttioNotFound = (error: unknown): boolean =>
+  getAttioErrorStatus(error) === 404;
+
+const isRetryableAttioError = (error: unknown): boolean => {
+  const info = parseAttioErrorInfo(error);
+  if (info?.isNetworkError) {
+    return true;
+  }
+  const status = getAttioErrorStatus(error);
+  return status !== undefined && RETRYABLE_ATTIO_STATUS_CODES.includes(status);
+};
+
 const normalizeAttioError = (
   error: unknown,
   context: AttioErrorContext = {},
@@ -200,15 +268,19 @@ const normalizeAttioError = (
   return networkError;
 };
 
-export type { AttioErrorDetails, AttioErrorContext };
+export type { AttioErrorContext, AttioErrorDetails };
 export {
-  AttioError,
   AttioApiError,
   AttioBatchError,
   AttioConfigError,
   AttioEnvironmentError,
+  AttioError,
   AttioNetworkError,
   AttioResponseError,
   AttioRetryError,
+  getAttioErrorStatus,
+  isAttioError,
+  isAttioNotFound,
+  isRetryableAttioError,
   normalizeAttioError,
 };

--- a/src/attio/filters.ts
+++ b/src/attio/filters.ts
@@ -123,6 +123,25 @@ type PathSegment = z.output<typeof pathSegmentSchema>;
 type PathFilter = z.output<typeof pathFilterSchema>;
 type AttioFilter = z.output<typeof attioFilterSchema>;
 
+interface ParentRecordIdFilterInput {
+  list: string;
+  object: string;
+  recordId: string;
+}
+
+interface ParentRecordContainsFilterInput {
+  list: string;
+  object: string;
+  attribute: string;
+  value: string;
+  field?: string;
+}
+
+interface ListStatusFilterInput {
+  attribute: string;
+  status: string;
+}
+
 const parseAttioFilter = (filter: AttioFilter): Record<string, unknown> =>
   attioFilterSchema.parse(filter);
 
@@ -187,6 +206,38 @@ const filters = {
       constraints,
     };
   },
+
+  parentRecordId: ({
+    list,
+    object,
+    recordId,
+  }: ParentRecordIdFilterInput): PathFilter =>
+    filters.path(
+      [
+        [list, "parent_record"],
+        [object, "record_id"],
+      ],
+      { value: recordId },
+    ),
+
+  parentRecordContains: ({
+    list,
+    object,
+    attribute,
+    value,
+    field = "value",
+  }: ParentRecordContainsFilterInput): PathFilter =>
+    filters.path(
+      [
+        [list, "parent_record"],
+        [object, attribute],
+      ],
+      { [field]: { $contains: value } },
+    ),
+
+  listStatus: ({ attribute, status }: ListStatusFilterInput): AttioFilter => ({
+    [attribute]: { status: { $eq: status } },
+  }),
 };
 
 export type {
@@ -196,6 +247,9 @@ export type {
   ComparisonOperator,
   FieldCondition,
   FilterValue,
+  ListStatusFilterInput,
+  ParentRecordContainsFilterInput,
+  ParentRecordIdFilterInput,
   PathFilter,
   PathSegment,
   ShorthandValue,

--- a/src/attio/hooks.ts
+++ b/src/attio/hooks.ts
@@ -51,9 +51,9 @@ interface AttioLogger {
 export type {
   AttioClientHooks,
   AttioErrorHookPayload,
-  LogContext,
-  LogValue,
   AttioLogger,
   AttioRequestHookPayload,
   AttioResponseHookPayload,
+  LogContext,
+  LogValue,
 };

--- a/src/attio/ids.ts
+++ b/src/attio/ids.ts
@@ -1,3 +1,5 @@
+import { z } from "zod";
+
 type BrandedId<TBrand extends string> = string & { readonly __brand: TBrand };
 
 const createBrandedId = <TBrand extends string>(
@@ -10,5 +12,13 @@ const createBrandedId = <TBrand extends string>(
   return id as BrandedId<TBrand>;
 };
 
-export { createBrandedId };
+const createBrandedIdSchema = <TBrand extends string>(label: string) =>
+  z
+    .string()
+    .refine((id) => id.trim().length > 0, {
+      message: `${label} cannot be empty`,
+    })
+    .transform((id) => createBrandedId<TBrand>(id, label));
+
 export type { BrandedId };
+export { createBrandedId, createBrandedIdSchema };

--- a/src/attio/lists.ts
+++ b/src/attio/lists.ts
@@ -18,22 +18,18 @@ import {
   postV2ListsByListEntriesQuery,
 } from "../generated";
 import { zPostV2ListsByListEntriesResponse } from "../generated/zod.gen";
-import { type AttioClientInput, resolveAttioClient } from "./client";
-import { type AttioFilter, parseAttioFilter } from "./filters";
-import { type BrandedId, createBrandedId } from "./ids";
+import type { AttioClientInput } from "./client";
+import type { AttioFilter } from "./filters";
+import { type BrandedId, createBrandedIdSchema } from "./ids";
 import {
   callAndDelete,
   callAndUnwrapData,
   callAndUnwrapItems,
+  createRecordQueryRuntime,
   unwrapAndNormalizeRecords,
 } from "./operations";
-import {
-  paginateOffset,
-  paginateOffsetAsync,
-  type SharedPaginationInput,
-} from "./pagination";
+import { resolveOffsetItems, type SharedPaginationInput } from "./pagination";
 import type { AttioRecordLike } from "./record-utils";
-import { rawRecordSchema } from "./schemas";
 
 const listSchema: z.ZodType<List> = z
   .object({
@@ -81,14 +77,19 @@ type EntryId = BrandedId<"EntryId">;
 type ParentObjectId = BrandedId<"ParentObjectId">;
 type ParentRecordId = BrandedId<"ParentRecordId">;
 
-const createListId = (id: string): ListId =>
-  createBrandedId<"ListId">(id, "ListId");
-const createEntryId = (id: string): EntryId =>
-  createBrandedId<"EntryId">(id, "EntryId");
+const listIdSchema = createBrandedIdSchema<"ListId">("ListId");
+const entryIdSchema = createBrandedIdSchema<"EntryId">("EntryId");
+const parentObjectIdSchema =
+  createBrandedIdSchema<"ParentObjectId">("ParentObjectId");
+const parentRecordIdSchema =
+  createBrandedIdSchema<"ParentRecordId">("ParentRecordId");
+
+const createListId = (id: string): ListId => listIdSchema.parse(id);
+const createEntryId = (id: string): EntryId => entryIdSchema.parse(id);
 const createParentObjectId = (id: string): ParentObjectId =>
-  createBrandedId<"ParentObjectId">(id, "ParentObjectId");
+  parentObjectIdSchema.parse(id);
 const createParentRecordId = (id: string): ParentRecordId =>
-  createBrandedId<"ParentRecordId">(id, "ParentRecordId");
+  parentRecordIdSchema.parse(id);
 
 type EntryValues = PostV2ListsByListEntriesData["body"]["data"]["entry_values"];
 
@@ -212,10 +213,7 @@ export function queryListEntries(
 export function queryListEntries<T extends AttioRecordLike>(
   input: ListQueryInput<T>,
 ): Promise<T[]> | AsyncIterable<T> {
-  const client = resolveAttioClient(input);
-  const schema = input.itemSchema ?? rawRecordSchema;
-  const filter =
-    input.filter === undefined ? undefined : parseAttioFilter(input.filter);
+  const query = createRecordQueryRuntime(input);
 
   const fetchEntries = async (
     offset?: number,
@@ -223,46 +221,16 @@ export function queryListEntries<T extends AttioRecordLike>(
     signal?: AbortSignal,
   ): Promise<T[]> => {
     const result = await postV2ListsByListEntriesQuery({
-      client,
+      client: query.client,
       path: { list: input.list },
-      body: { filter, limit, offset },
+      body: { filter: query.filter, limit, offset },
       ...input.options,
       signal,
     });
-    return unwrapAndNormalizeRecords(result, schema) as T[];
+    return unwrapAndNormalizeRecords(result, query.schema);
   };
 
-  if (input.paginate === "stream") {
-    return paginateOffsetAsync<T>(
-      async (offset, limit, signal) => ({
-        items: await fetchEntries(offset, limit, signal),
-      }),
-      {
-        offset: input.offset,
-        limit: input.limit,
-        maxPages: input.maxPages,
-        maxItems: input.maxItems,
-        signal: input.signal,
-      },
-    );
-  }
-
-  if (input.paginate === true) {
-    return paginateOffset<T>(
-      async (offset, limit, signal) => ({
-        items: await fetchEntries(offset, limit, signal),
-      }),
-      {
-        offset: input.offset,
-        limit: input.limit,
-        maxPages: input.maxPages,
-        maxItems: input.maxItems,
-        signal: input.signal,
-      },
-    );
-  }
-
-  return fetchEntries(input.offset, input.limit, input.signal);
+  return resolveOffsetItems(fetchEntries, input);
 }
 
 export const addListEntry = async (
@@ -311,13 +279,6 @@ export const removeListEntry = async (input: RemoveListEntryInput) =>
     }),
   );
 
-export {
-  createEntryId,
-  createListId,
-  createParentObjectId,
-  createParentRecordId,
-};
-
 export type {
   AddListEntryInput,
   EntryId,
@@ -336,4 +297,14 @@ export type {
   ParentRecordId,
   RemoveListEntryInput,
   UpdateListEntryInput,
+};
+export {
+  createEntryId,
+  createListId,
+  createParentObjectId,
+  createParentRecordId,
+  entryIdSchema,
+  listIdSchema,
+  parentObjectIdSchema,
+  parentRecordIdSchema,
 };

--- a/src/attio/logging.ts
+++ b/src/attio/logging.ts
@@ -330,17 +330,17 @@ const createStructuredLoggerHooks = ({
   };
 };
 
-export {
-  DEFAULT_CORRELATION_ID_CONTEXT_KEY,
-  DEFAULT_CORRELATION_ID_HEADER,
-  createCorrelationIdManager,
-  createStructuredLoggerHooks,
-  redactLogContext,
-};
 export type {
   AttioCorrelationIdConfig,
-  AttioLogRedactionConfig,
   AttioLoggingConfig,
+  AttioLogRedactionConfig,
   CorrelationIdManager,
   StructuredLoggerHooksInput,
+};
+export {
+  createCorrelationIdManager,
+  createStructuredLoggerHooks,
+  DEFAULT_CORRELATION_ID_CONTEXT_KEY,
+  DEFAULT_CORRELATION_ID_HEADER,
+  redactLogContext,
 };

--- a/src/attio/metadata.ts
+++ b/src/attio/metadata.ts
@@ -26,6 +26,7 @@ import {
   resolveAttioClient,
 } from "./client";
 import { updateKnownFieldValues } from "./error-enhancer";
+import { AttioConfigError, AttioResponseError } from "./errors";
 import { createSchemaError, unwrapData, unwrapItems } from "./response";
 
 const getMetadataCache = (
@@ -88,6 +89,36 @@ interface AttributeMetadataInput<TData extends AttributeMetadataData>
   extends AttioClientInput,
     AttributePathWithAttribute {
   options?: Partial<Omit<Options<TData>, "client" | "path">>;
+}
+
+interface AttributeFindInput extends AttioClientInput, AttributePathInput {
+  slug?: AttributeSlug;
+  title?: string;
+  type?: ZodAttribute["type"];
+  options?: Omit<
+    Options<GetV2ByTargetByIdentifierAttributesData>,
+    "client" | "path"
+  >;
+}
+
+type AllowedValueAttributeType = "select" | "status";
+
+interface ListAllowedValuesInput
+  extends AttioClientInput,
+    AttributePathWithAttribute {
+  type?: AllowedValueAttributeType;
+  options?: Partial<
+    Omit<
+      Options<GetV2ByTargetByIdentifierAttributesByAttributeOptionsData>,
+      "client" | "path"
+    >
+  >;
+}
+
+interface NormalizedAllowedValue {
+  id: string;
+  title: string;
+  archived: boolean;
 }
 
 interface AttributeMetadataPath extends AttributePathWithAttribute {}
@@ -226,19 +257,108 @@ const getAttributeStatuses = (
   });
 };
 
+const hasFindCriteria = (input: AttributeFindInput): boolean =>
+  input.slug !== undefined ||
+  input.title !== undefined ||
+  input.type !== undefined;
+
+const attributeMatchesFindInput = (
+  attribute: ZodAttribute,
+  input: AttributeFindInput,
+): boolean =>
+  (input.slug === undefined || attribute.api_slug === input.slug) &&
+  (input.title === undefined || attribute.title === input.title) &&
+  (input.type === undefined || attribute.type === input.type);
+
+const findAttribute = async (
+  input: AttributeFindInput,
+): Promise<ZodAttribute | undefined> => {
+  if (!hasFindCriteria(input)) {
+    throw new AttioConfigError(
+      "findAttribute requires at least one of slug, title, or type.",
+      { code: "MISSING_ATTRIBUTE_CRITERIA" },
+    );
+  }
+
+  const attributes = await listAttributes(input);
+  return attributes.find((attribute) =>
+    attributeMatchesFindInput(attribute, input),
+  );
+};
+
+const normalizeSelectOption = (
+  option: SelectOption,
+): NormalizedAllowedValue => ({
+  id: option.id.option_id,
+  title: option.title,
+  archived: option.is_archived,
+});
+
+const normalizeStatus = (status: Status): NormalizedAllowedValue => ({
+  id: status.id.status_id,
+  title: status.title,
+  archived: status.is_archived,
+});
+
+const resolveAllowedValueType = async (
+  input: ListAllowedValuesInput,
+): Promise<AllowedValueAttributeType> => {
+  if (input.type !== undefined) {
+    return input.type;
+  }
+
+  const attribute = await getAttribute({
+    client: input.client,
+    config: input.config,
+    target: input.target,
+    identifier: input.identifier,
+    attribute: input.attribute,
+  });
+  if (attribute.type === "select" || attribute.type === "status") {
+    return attribute.type;
+  }
+
+  throw new AttioResponseError("Attribute does not expose allowed values.", {
+    code: "UNSUPPORTED_ATTRIBUTE_TYPE",
+    data: { attribute: input.attribute, type: attribute.type },
+  });
+};
+
+const listAllowedValues = async (
+  input: ListAllowedValuesInput,
+): Promise<NormalizedAllowedValue[]> => {
+  const type = await resolveAllowedValueType(input);
+  if (type === "select") {
+    const options = await getAttributeOptions(input);
+    return options.map(normalizeSelectOption);
+  }
+
+  const statuses = await getAttributeStatuses(input);
+  return statuses.map(normalizeStatus);
+};
+
 export type {
-  AttributeListInput,
+  AllowedValueAttributeType,
+  AttributeFindInput,
+  AttributeIdentifier,
   AttributeInput,
+  AttributeListInput,
   AttributeMetadataRequestParams,
+  AttributeSlug,
+  AttributeTarget,
+  ListAllowedValuesInput,
+  NormalizedAllowedValue,
   ZodAttribute,
 };
 export {
-  listAttributes,
-  getAttribute,
-  getAttributeOptions,
-  getAttributeStatuses,
-  listAttributeMetadata,
   buildAttributeMetadataPath,
   buildKey,
   extractTitles,
+  findAttribute,
+  getAttribute,
+  getAttributeOptions,
+  getAttributeStatuses,
+  listAllowedValues,
+  listAttributeMetadata,
+  listAttributes,
 };

--- a/src/attio/notes.ts
+++ b/src/attio/notes.ts
@@ -13,7 +13,7 @@ import {
 } from "../generated";
 import { zNote } from "../generated/zod.gen";
 import type { AttioClientInput } from "./client";
-import { type BrandedId, createBrandedId } from "./ids";
+import { type BrandedId, createBrandedIdSchema } from "./ids";
 import {
   callAndDelete,
   callAndUnwrapData,
@@ -27,12 +27,19 @@ type NoteParentObjectId = BrandedId<"NoteParentObjectId">;
 type NoteParentRecordId = BrandedId<"NoteParentRecordId">;
 type NoteFormat = PostV2NotesData["body"]["data"]["format"];
 
-const createNoteId = (id: string): NoteId =>
-  createBrandedId<"NoteId">(id, "NoteId");
+const noteIdSchema = createBrandedIdSchema<"NoteId">("NoteId");
+const noteParentObjectIdSchema = createBrandedIdSchema<"NoteParentObjectId">(
+  "Note parent object id",
+);
+const noteParentRecordIdSchema = createBrandedIdSchema<"NoteParentRecordId">(
+  "Note parent record id",
+);
+
+const createNoteId = (id: string): NoteId => noteIdSchema.parse(id);
 const createNoteParentObjectId = (id: string): NoteParentObjectId =>
-  createBrandedId<"NoteParentObjectId">(id, "Note parent object id");
+  noteParentObjectIdSchema.parse(id);
 const createNoteParentRecordId = (id: string): NoteParentRecordId =>
-  createBrandedId<"NoteParentRecordId">(id, "Note parent record id");
+  noteParentRecordIdSchema.parse(id);
 
 export interface NoteCreateInput extends AttioClientInput {
   parentObject: NoteParentObjectId;
@@ -105,5 +112,12 @@ export const deleteNote = async (input: NoteDeleteInput): Promise<true> =>
     }),
   );
 
-export { createNoteId, createNoteParentObjectId, createNoteParentRecordId };
 export type { NoteFormat, NoteId, NoteParentObjectId, NoteParentRecordId };
+export {
+  createNoteId,
+  createNoteParentObjectId,
+  createNoteParentRecordId,
+  noteIdSchema,
+  noteParentObjectIdSchema,
+  noteParentRecordIdSchema,
+};

--- a/src/attio/objects.ts
+++ b/src/attio/objects.ts
@@ -14,12 +14,25 @@ import {
   postV2Objects,
 } from "../generated";
 import type { AttioClientInput } from "./client";
+import { type BrandedId, createBrandedIdSchema } from "./ids";
 import { callAndUnwrapData, callAndUnwrapItems } from "./operations";
 
-type ObjectSlug = string & { readonly __brand: "ObjectSlug" };
-type ObjectApiSlug = string & { readonly __brand: "ObjectApiSlug" };
-type ObjectNoun = string & { readonly __brand: "ObjectNoun" };
+type ObjectSlug = BrandedId<"ObjectSlug">;
+type ObjectApiSlug = BrandedId<"ObjectApiSlug">;
+type ObjectNoun = BrandedId<"ObjectNoun">;
 type ObjectUpdateData = PatchV2ObjectsByObjectData["body"]["data"];
+
+const objectSlugSchema = createBrandedIdSchema<"ObjectSlug">("ObjectSlug");
+const objectApiSlugSchema =
+  createBrandedIdSchema<"ObjectApiSlug">("Object API slug");
+const objectNounSchema = createBrandedIdSchema<"ObjectNoun">("ObjectNoun");
+
+const createObjectSlug = (slug: string): ObjectSlug =>
+  objectSlugSchema.parse(slug);
+const createObjectApiSlug = (slug: string): ObjectApiSlug =>
+  objectApiSlugSchema.parse(slug);
+const createObjectNoun = (noun: string): ObjectNoun =>
+  objectNounSchema.parse(noun);
 
 const AttioObjectSchema: z.ZodType<AttioObject> = z
   .object({
@@ -127,4 +140,15 @@ export type {
   ObjectSlug,
   UpdateObjectInput,
 };
-export { createObject, getObject, listObjects, updateObject };
+export {
+  createObject,
+  createObjectApiSlug,
+  createObjectNoun,
+  createObjectSlug,
+  getObject,
+  listObjects,
+  objectApiSlugSchema,
+  objectNounSchema,
+  objectSlugSchema,
+  updateObject,
+};

--- a/src/attio/operations.ts
+++ b/src/attio/operations.ts
@@ -4,6 +4,7 @@ import {
   type AttioClientInput,
   resolveAttioClient,
 } from "./client";
+import { type AttioFilter, parseAttioFilter } from "./filters";
 import {
   type AttioRecordLike,
   normalizeRecord,
@@ -19,6 +20,27 @@ import {
   validateWithSchema,
 } from "./response";
 import { rawRecordSchema } from "./schemas";
+
+interface RecordQueryRuntime<T extends AttioRecordLike> {
+  client: AttioClient;
+  filter?: Record<string, unknown>;
+  schema: ZodType<T>;
+}
+
+interface RecordQueryRuntimeInput<T extends AttioRecordLike>
+  extends AttioClientInput {
+  filter?: AttioFilter;
+  itemSchema?: ZodType<T>;
+}
+
+const createRecordQueryRuntime = <T extends AttioRecordLike>(
+  input: RecordQueryRuntimeInput<T>,
+): RecordQueryRuntime<T> => ({
+  client: resolveAttioClient(input),
+  filter:
+    input.filter === undefined ? undefined : parseAttioFilter(input.filter),
+  schema: (input.itemSchema ?? rawRecordSchema) as ZodType<T>,
+});
 
 /**
  * Resolve client, execute API call, and unwrap a single data response.
@@ -100,5 +122,6 @@ export {
   callAndUnwrapData,
   callAndUnwrapItems,
   callAndUnwrapRecord,
+  createRecordQueryRuntime,
   unwrapAndNormalizeRecords,
 };

--- a/src/attio/pagination.ts
+++ b/src/attio/pagination.ts
@@ -48,6 +48,15 @@ interface SharedPaginationInput {
   signal?: AbortSignal;
 }
 
+interface SharedOffsetPaginationInput extends SharedPaginationInput {
+  offset?: number;
+  limit?: number;
+}
+
+interface OffsetItemsQueryInput extends SharedOffsetPaginationInput {
+  paginate?: boolean | "stream";
+}
+
 const createPageResultSchema = <T>(
   itemSchema: ZodType<T>,
 ): ZodType<PageResult<T>> =>
@@ -118,30 +127,86 @@ const parseOffsetPageResult = <T>(
   return result.data;
 };
 
+interface PaginationLoopState {
+  pages: number;
+  itemCount: number;
+  maxPages: number;
+  maxItems: number;
+  signal?: AbortSignal;
+}
+
+const createPaginationLoopState = (
+  options: SharedPaginationInput,
+): PaginationLoopState => ({
+  pages: 0,
+  itemCount: 0,
+  maxPages: options.maxPages ?? Number.POSITIVE_INFINITY,
+  maxItems: options.maxItems ?? Number.POSITIVE_INFINITY,
+  signal: options.signal,
+});
+
+const shouldContinuePagination = (state: PaginationLoopState): boolean =>
+  state.pages < state.maxPages &&
+  state.itemCount < state.maxItems &&
+  !isAborted(state.signal);
+
+type CursorPageFetcher<T> = (
+  cursor: string | null | undefined,
+  signal?: AbortSignal,
+) => Promise<PageResult<T> | unknown>;
+
+type OffsetPageFetcher<T> = (
+  offset: number,
+  limit: number,
+  signal?: AbortSignal,
+) => Promise<OffsetPageResult<T> | unknown>;
+
+const readCursorPage = async <T>(
+  fetchPage: CursorPageFetcher<T>,
+  cursor: string | null | undefined,
+  options: PaginationAsyncOptions<T>,
+): Promise<PageResult<T>> => {
+  const page = await fetchPage(cursor, options.signal);
+  const parsed = parsePageResult(page, options.itemSchema);
+  return parsed ?? toPageResult<T>(page);
+};
+
+const readOffsetPage = async <T>(
+  fetchPage: OffsetPageFetcher<T>,
+  offset: number,
+  limit: number,
+  options: OffsetPaginationAsyncOptions<T>,
+): Promise<OffsetPageResult<T>> => {
+  const page = await fetchPage(offset, limit, options.signal);
+  const parsed = parseOffsetPageResult(page, options.itemSchema);
+  return parsed ?? toOffsetPageResult<T>(page);
+};
+
+const addCompletedPage = (
+  state: PaginationLoopState,
+  itemCount: number,
+): void => {
+  state.pages += 1;
+  state.itemCount = itemCount;
+};
+
 const paginate = async <T>(
-  fetchPage: (
-    cursor: string | null | undefined,
-    signal?: AbortSignal,
-  ) => Promise<PageResult<T> | unknown>,
+  fetchPage: CursorPageFetcher<T>,
   options: PaginationAsyncOptions<T> = {},
 ): Promise<T[]> => {
   const items: T[] = [];
   let cursor = options.cursor ?? null;
-  let pages = 0;
-  const maxPages = options.maxPages ?? Number.POSITIVE_INFINITY;
-  const maxItems = options.maxItems ?? Number.POSITIVE_INFINITY;
+  const state = createPaginationLoopState(options);
 
-  while (
-    pages < maxPages &&
-    items.length < maxItems &&
-    !isAborted(options.signal)
-  ) {
-    const page = await fetchPage(cursor, options.signal);
-    const parsed = parsePageResult(page, options.itemSchema);
-    const { items: pageItems, nextCursor } = parsed ?? toPageResult<T>(page);
+  while (shouldContinuePagination(state)) {
+    const { items: pageItems, nextCursor } = await readCursorPage(
+      fetchPage,
+      cursor,
+      options,
+    );
 
     items.push(...pageItems);
-    pages += 1;
+    addCompletedPage(state, items.length);
 
     if (!nextCursor) {
       break;
@@ -150,7 +215,7 @@ const paginate = async <T>(
     cursor = nextCursor;
   }
 
-  return items.slice(0, maxItems);
+  return items.slice(0, state.maxItems);
 };
 
 const DEFAULT_OFFSET_PAGE_SIZE = 50;
@@ -177,74 +242,146 @@ const resolveNextOffset = ({
   return currentOffset + limit;
 };
 
-interface OffsetPaginationState {
-  pages: number;
-  itemCount: number;
-  maxPages: number;
-  maxItems: number;
-  signal?: AbortSignal;
+interface OffsetPaginationRuntime {
+  limit: number;
+  offset: number;
+  state: PaginationLoopState;
 }
 
-const shouldContinueOffsetPagination = (
-  state: OffsetPaginationState,
-): boolean =>
-  state.pages < state.maxPages &&
-  state.itemCount < state.maxItems &&
-  !isAborted(state.signal);
+interface OffsetPageRead<T> {
+  pageItems: T[];
+  nextOffset?: number | null;
+  currentOffset: number;
+  limit: number;
+}
 
-const paginateOffset = async <T>(
-  fetchPage: (
+const createOffsetPaginationRuntime = (
+  options: OffsetPaginationAsyncOptions,
+): OffsetPaginationRuntime => ({
+  limit: Math.max(
+    1,
+    options.limit ?? options.pageSize ?? DEFAULT_OFFSET_PAGE_SIZE,
+  ),
+  offset: Math.max(0, options.offset ?? 0),
+  state: createPaginationLoopState(options),
+});
+
+type OffsetItemsFetcher<T> = (
+  offset?: number,
+  limit?: number,
+  signal?: AbortSignal,
+) => Promise<T[]>;
+
+const toOffsetItemsPageFetcher =
+  <T>(fetchItems: OffsetItemsFetcher<T>) =>
+  async (
     offset: number,
     limit: number,
-    signal?: AbortSignal,
-  ) => Promise<OffsetPageResult<T> | unknown>,
+    signal: AbortSignal | undefined,
+  ): Promise<OffsetPageResult<T>> => ({
+    items: await fetchItems(offset, limit, signal),
+  });
+
+const collectOffsetItems = <T>(
+  fetchItems: OffsetItemsFetcher<T>,
+  input: SharedOffsetPaginationInput,
+): Promise<T[]> =>
+  paginateOffset(toOffsetItemsPageFetcher(fetchItems), {
+    offset: input.offset,
+    limit: input.limit,
+    maxPages: input.maxPages,
+    maxItems: input.maxItems,
+    signal: input.signal,
+  });
+
+const streamOffsetItems = <T>(
+  fetchItems: OffsetItemsFetcher<T>,
+  input: SharedOffsetPaginationInput,
+): AsyncIterable<T> =>
+  paginateOffsetAsync(toOffsetItemsPageFetcher(fetchItems), {
+    offset: input.offset,
+    limit: input.limit,
+    maxPages: input.maxPages,
+    maxItems: input.maxItems,
+    signal: input.signal,
+  });
+
+const resolveOffsetItems = <T>(
+  fetchItems: OffsetItemsFetcher<T>,
+  input: OffsetItemsQueryInput,
+): Promise<T[]> | AsyncIterable<T> => {
+  if (input.paginate === "stream") {
+    return streamOffsetItems(fetchItems, input);
+  }
+
+  if (input.paginate === true) {
+    return collectOffsetItems(fetchItems, input);
+  }
+
+  return fetchItems(input.offset, input.limit, input.signal);
+};
+
+const readRuntimeOffsetPage = async <T>(
+  fetchPage: OffsetPageFetcher<T>,
+  runtime: OffsetPaginationRuntime,
+  options: OffsetPaginationAsyncOptions<T>,
+): Promise<OffsetPageRead<T>> => {
+  const { items: pageItems, nextOffset } = await readOffsetPage(
+    fetchPage,
+    runtime.offset,
+    runtime.limit,
+    options,
+  );
+  return {
+    pageItems,
+    nextOffset,
+    currentOffset: runtime.offset,
+    limit: runtime.limit,
+  };
+};
+
+const advanceOffset = <T>(
+  runtime: OffsetPaginationRuntime,
+  page: OffsetPageRead<T>,
+): boolean => {
+  const resolvedOffset = resolveNextOffset({
+    nextOffset: page.nextOffset,
+    pageItemsLength: page.pageItems.length,
+    limit: page.limit,
+    currentOffset: page.currentOffset,
+  });
+
+  if (resolvedOffset === null || resolvedOffset <= page.currentOffset) {
+    return false;
+  }
+
+  runtime.offset = resolvedOffset;
+  return true;
+};
+
+const paginateOffset = async <T>(
+  fetchPage: OffsetPageFetcher<T>,
   options: OffsetPaginationAsyncOptions<T> = {},
 ): Promise<T[]> => {
   const items: T[] = [];
-  const maxPages = options.maxPages ?? Number.POSITIVE_INFINITY;
-  const maxItems = options.maxItems ?? Number.POSITIVE_INFINITY;
-  const limit = Math.max(
-    1,
-    options.limit ?? options.pageSize ?? DEFAULT_OFFSET_PAGE_SIZE,
-  );
-  let offset = Math.max(0, options.offset ?? 0);
-  const state: OffsetPaginationState = {
-    pages: 0,
-    itemCount: 0,
-    maxPages,
-    maxItems,
-    signal: options.signal,
-  };
+  const runtime = createOffsetPaginationRuntime(options);
 
-  while (shouldContinueOffsetPagination(state)) {
-    const page = await fetchPage(offset, limit, options.signal);
-    const parsed = parseOffsetPageResult(page, options.itemSchema);
-    const { items: pageItems, nextOffset } =
-      parsed ?? toOffsetPageResult<T>(page);
+  while (shouldContinuePagination(runtime.state)) {
+    const page = await readRuntimeOffsetPage(fetchPage, runtime, options);
 
-    items.push(...pageItems);
-    state.pages += 1;
-    state.itemCount = items.length;
+    items.push(...page.pageItems);
+    addCompletedPage(runtime.state, items.length);
 
-    if (!shouldContinueOffsetPagination(state)) {
+    if (!shouldContinuePagination(runtime.state)) {
       break;
     }
 
-    const resolvedOffset = resolveNextOffset({
-      nextOffset,
-      pageItemsLength: pageItems.length,
-      limit,
-      currentOffset: offset,
-    });
-
-    if (resolvedOffset === null || resolvedOffset <= offset) {
+    if (!advanceOffset(runtime, page)) {
       break;
     }
-
-    offset = resolvedOffset;
   }
 
-  return items.slice(0, maxItems);
+  return items.slice(0, runtime.state.maxItems);
 };
 
 const isAborted = (signal: AbortSignal | undefined): boolean =>
@@ -266,39 +403,41 @@ function* yieldItems<T>(
   return false;
 }
 
+function* yieldPageItems<T>(
+  pageItems: T[],
+  state: PaginationLoopState,
+): Generator<T, boolean> {
+  const yieldState = { yielded: state.itemCount };
+  const stopped = yield* yieldItems(
+    pageItems,
+    state.signal,
+    yieldState,
+    state.maxItems,
+  );
+  if (!stopped) {
+    addCompletedPage(state, yieldState.yielded);
+  }
+  return stopped;
+}
+
 async function* paginateAsync<T>(
-  fetchPage: (
-    cursor: string | null | undefined,
-    signal: AbortSignal | undefined,
-  ) => Promise<PageResult<T> | unknown>,
+  fetchPage: CursorPageFetcher<T>,
   options: PaginationAsyncOptions<T> = {},
 ): AsyncIterable<T> {
   let cursor = options.cursor ?? null;
-  let pages = 0;
-  const state = { yielded: 0 };
-  const maxPages = options.maxPages ?? Number.POSITIVE_INFINITY;
-  const maxItems = options.maxItems ?? Number.POSITIVE_INFINITY;
+  const state = createPaginationLoopState(options);
 
-  while (
-    pages < maxPages &&
-    state.yielded < maxItems &&
-    !isAborted(options.signal)
-  ) {
-    const page = await fetchPage(cursor, options.signal);
-    const parsed = parsePageResult(page, options.itemSchema);
-    const { items: pageItems, nextCursor } = parsed ?? toPageResult<T>(page);
-
-    const stopped = yield* yieldItems(
-      pageItems,
-      options.signal,
-      state,
-      maxItems,
+  while (shouldContinuePagination(state)) {
+    const { items: pageItems, nextCursor } = await readCursorPage(
+      fetchPage,
+      cursor,
+      options,
     );
-    if (stopped) {
+
+    if (yield* yieldPageItems(pageItems, state)) {
       return;
     }
 
-    pages += 1;
     if (!nextCursor) {
       return;
     }
@@ -307,68 +446,37 @@ async function* paginateAsync<T>(
 }
 
 async function* paginateOffsetAsync<T>(
-  fetchPage: (
-    offset: number,
-    limit: number,
-    signal: AbortSignal | undefined,
-  ) => Promise<OffsetPageResult<T> | unknown>,
+  fetchPage: OffsetPageFetcher<T>,
   options: OffsetPaginationAsyncOptions<T> = {},
 ): AsyncIterable<T> {
-  const maxPages = options.maxPages ?? Number.POSITIVE_INFINITY;
-  const maxItems = options.maxItems ?? Number.POSITIVE_INFINITY;
-  const limit = Math.max(
-    1,
-    options.limit ?? options.pageSize ?? DEFAULT_OFFSET_PAGE_SIZE,
-  );
-  let offset = Math.max(0, options.offset ?? 0);
-  let pages = 0;
-  const state = { yielded: 0 };
+  const runtime = createOffsetPaginationRuntime(options);
 
-  while (
-    pages < maxPages &&
-    state.yielded < maxItems &&
-    !isAborted(options.signal)
-  ) {
-    const page = await fetchPage(offset, limit, options.signal);
-    const parsed = parseOffsetPageResult(page, options.itemSchema);
-    const { items: pageItems, nextOffset } =
-      parsed ?? toOffsetPageResult<T>(page);
+  while (shouldContinuePagination(runtime.state)) {
+    const page = await readRuntimeOffsetPage(fetchPage, runtime, options);
 
-    const stopped = yield* yieldItems(
-      pageItems,
-      options.signal,
-      state,
-      maxItems,
-    );
-    if (stopped) {
+    if (yield* yieldPageItems(page.pageItems, runtime.state)) {
       return;
     }
 
-    pages += 1;
-    const resolvedOffset = resolveNextOffset({
-      nextOffset,
-      pageItemsLength: pageItems.length,
-      limit,
-      currentOffset: offset,
-    });
-
-    if (resolvedOffset === null || resolvedOffset <= offset) {
+    if (!advanceOffset(runtime, page)) {
       return;
     }
-    offset = resolvedOffset;
   }
 }
 
 export type {
+  OffsetItemsQueryInput,
   OffsetPageResult,
   OffsetPaginationAsyncOptions,
   OffsetPaginationOptions,
   PageResult,
   PaginationAsyncOptions,
   PaginationOptions,
+  SharedOffsetPaginationInput,
   SharedPaginationInput,
 };
 export {
+  collectOffsetItems,
   createOffsetPageResultSchema,
   createPageResultSchema,
   paginate,
@@ -377,6 +485,8 @@ export {
   paginateOffsetAsync,
   parseOffsetPageResult,
   parsePageResult,
+  resolveOffsetItems,
+  streamOffsetItems,
   toOffsetPageResult,
   toPageResult,
 };

--- a/src/attio/records.ts
+++ b/src/attio/records.ts
@@ -15,20 +15,19 @@ import {
   postV2ObjectsByObjectRecordsQuery,
   putV2ObjectsByObjectRecords,
 } from "../generated";
+import { runBatch } from "./batch";
 import { type AttioClientInput, resolveAttioClient } from "./client";
-import { type AttioFilter, parseAttioFilter } from "./filters";
-import { type BrandedId, createBrandedId } from "./ids";
+import { AttioResponseError } from "./errors";
+import { type AttioFilter, filters, parseAttioFilter } from "./filters";
+import { type BrandedId, createBrandedIdSchema } from "./ids";
 import {
   callAndDelete,
   callAndUnwrapRecord,
+  createRecordQueryRuntime,
   unwrapAndNormalizeRecords,
 } from "./operations";
-import {
-  paginateOffset,
-  paginateOffsetAsync,
-  type SharedPaginationInput,
-} from "./pagination";
-import type { AttioRecordLike } from "./record-utils";
+import { resolveOffsetItems, type SharedPaginationInput } from "./pagination";
+import { type AttioRecordLike, extractRecordId } from "./record-utils";
 import { rawRecordSchema } from "./schemas";
 
 /**
@@ -46,12 +45,17 @@ type RecordObjectId = BrandedId<"RecordObjectId">;
 type RecordId = BrandedId<"RecordId">;
 type MatchingAttribute = BrandedId<"MatchingAttribute">;
 
+const recordObjectIdSchema =
+  createBrandedIdSchema<"RecordObjectId">("RecordObjectId");
+const recordIdSchema = createBrandedIdSchema<"RecordId">("RecordId");
+const matchingAttributeSchema =
+  createBrandedIdSchema<"MatchingAttribute">("MatchingAttribute");
+
 const createRecordObjectId = (id: string): RecordObjectId =>
-  createBrandedId<"RecordObjectId">(id, "RecordObjectId");
-const createRecordId = (id: string): RecordId =>
-  createBrandedId<"RecordId">(id, "RecordId");
+  recordObjectIdSchema.parse(id);
+const createRecordId = (id: string): RecordId => recordIdSchema.parse(id);
 const createMatchingAttribute = (id: string): MatchingAttribute =>
-  createBrandedId<"MatchingAttribute">(id, "MatchingAttribute");
+  matchingAttributeSchema.parse(id);
 
 type RecordValues = PostV2ObjectsByObjectRecordsData["body"]["data"]["values"];
 type RecordSorts = PostV2ObjectsByObjectRecordsQueryData["body"]["sorts"];
@@ -142,6 +146,85 @@ type RecordQueryInput<T extends AttioRecordLike = AttioRecordLike> =
   | RecordQuerySingleInput<T>
   | RecordQueryCollectInput<T>
   | RecordQueryStreamInput<T>;
+
+type RecordGetManyNotFoundPolicy = "omit" | "throw";
+
+interface RecordGetManyInput<T extends AttioRecordLike = AttioRecordLike>
+  extends AttioClientInput {
+  object: RecordObjectId;
+  recordIds: readonly RecordId[];
+  chunkSize?: number;
+  concurrency?: number;
+  preserveOrder?: boolean;
+  notFound?: RecordGetManyNotFoundPolicy;
+  signal?: AbortSignal;
+  itemSchema?: ZodType<T>;
+  options?: Omit<
+    Options<PostV2ObjectsByObjectRecordsQueryData>,
+    "client" | "path" | "body"
+  >;
+}
+
+const DEFAULT_GET_MANY_CHUNK_SIZE = 100;
+const DEFAULT_GET_MANY_CONCURRENCY = 4;
+
+const chunkRecordIds = (
+  recordIds: readonly RecordId[],
+  chunkSize: number,
+): RecordId[][] => {
+  const chunks: RecordId[][] = [];
+  for (let index = 0; index < recordIds.length; index += chunkSize) {
+    chunks.push(recordIds.slice(index, index + chunkSize));
+  }
+  return chunks;
+};
+
+const clampPositiveInteger = (
+  value: number | undefined,
+  fallback: number,
+): number => {
+  if (value === undefined || !Number.isFinite(value) || value < 1) {
+    return fallback;
+  }
+  return Math.floor(value);
+};
+
+const missingRecordsError = (recordIds: readonly RecordId[]) =>
+  new AttioResponseError("Attio records were not found.", {
+    code: "RECORDS_NOT_FOUND",
+    data: { recordIds },
+  });
+
+const orderRecordsByInputIds = <T extends AttioRecordLike>(
+  records: T[],
+  recordIds: readonly RecordId[],
+  notFound: RecordGetManyNotFoundPolicy,
+): T[] => {
+  const byId = new Map<string, T>();
+  for (const record of records) {
+    const recordId = extractRecordId(record);
+    if (recordId) {
+      byId.set(recordId, record);
+    }
+  }
+
+  const ordered: T[] = [];
+  const missing: RecordId[] = [];
+  for (const recordId of recordIds) {
+    const record = byId.get(recordId);
+    if (record) {
+      ordered.push(record);
+    } else {
+      missing.push(recordId);
+    }
+  }
+
+  if (missing.length > 0 && notFound === "throw") {
+    throw missingRecordsError(missing);
+  }
+
+  return ordered;
+};
 
 // Overload: With itemSchema - T is inferred from schema
 function createRecord<T extends AttioRecordLike>(
@@ -259,10 +342,7 @@ function queryRecords(
 function queryRecords<T extends AttioRecordLike>(
   input: RecordQueryInput<T>,
 ): Promise<T[]> | AsyncIterable<T> {
-  const client = resolveAttioClient(input);
-  const schema = input.itemSchema ?? rawRecordSchema;
-  const filter =
-    input.filter === undefined ? undefined : parseAttioFilter(input.filter);
+  const query = createRecordQueryRuntime(input);
 
   const fetchRecords = async (
     offset?: number,
@@ -270,53 +350,97 @@ function queryRecords<T extends AttioRecordLike>(
     signal?: AbortSignal,
   ): Promise<T[]> => {
     const result = await postV2ObjectsByObjectRecordsQuery({
-      client,
+      client: query.client,
       path: { object: input.object },
-      body: { filter, sorts: input.sorts, limit, offset },
+      body: { filter: query.filter, sorts: input.sorts, limit, offset },
       ...input.options,
       signal,
     });
-    return unwrapAndNormalizeRecords(result, schema) as T[];
+    return unwrapAndNormalizeRecords(result, query.schema);
   };
 
-  if (input.paginate === "stream") {
-    return paginateOffsetAsync<T>(
-      async (offset, limit, signal) => ({
-        items: await fetchRecords(offset, limit, signal),
-      }),
-      {
-        offset: input.offset,
-        limit: input.limit,
-        maxPages: input.maxPages,
-        maxItems: input.maxItems,
-        signal: input.signal,
-      },
-    );
+  return resolveOffsetItems(fetchRecords, input);
+}
+
+// Overload: With itemSchema - T is inferred from schema
+function getManyRecords<T extends AttioRecordLike>(
+  input: RecordGetManyInput<T> & { itemSchema: ZodType<T> },
+): Promise<T[]>;
+// Overload: Without itemSchema - returns AttioRecordLike
+function getManyRecords(input: RecordGetManyInput): Promise<AttioRecordLike[]>;
+// Implementation
+async function getManyRecords<T extends AttioRecordLike>(
+  input: RecordGetManyInput<T>,
+): Promise<T[]> {
+  if (input.recordIds.length === 0) {
+    return [];
   }
 
-  if (input.paginate === true) {
-    return paginateOffset<T>(
-      async (offset, limit, signal) => ({
-        items: await fetchRecords(offset, limit, signal),
-      }),
-      {
-        offset: input.offset,
-        limit: input.limit,
-        maxPages: input.maxPages,
-        maxItems: input.maxItems,
-        signal: input.signal,
-      },
-    );
+  const client = resolveAttioClient(input);
+  const schema = input.itemSchema ?? rawRecordSchema;
+  const chunkSize = clampPositiveInteger(
+    input.chunkSize,
+    DEFAULT_GET_MANY_CHUNK_SIZE,
+  );
+  const chunks = chunkRecordIds(input.recordIds, chunkSize);
+  const batchItems = chunks.map((recordIds) => ({
+    label: recordIds.join(","),
+    run: async ({ signal }: { signal?: AbortSignal } = {}) => {
+      const result = await postV2ObjectsByObjectRecordsQuery({
+        client,
+        path: { object: input.object },
+        body: {
+          filter: parseAttioFilter(filters.in("record_id", [...recordIds])),
+          limit: recordIds.length,
+          offset: 0,
+        },
+        ...input.options,
+        signal: signal ?? input.signal,
+      });
+      return unwrapAndNormalizeRecords(result, schema) as T[];
+    },
+  }));
+
+  const results = await runBatch(batchItems, {
+    concurrency: clampPositiveInteger(
+      input.concurrency,
+      DEFAULT_GET_MANY_CONCURRENCY,
+    ),
+    stopOnError: true,
+  });
+
+  const records = results.flatMap((result) => result.value ?? []);
+  const notFound = input.notFound ?? "omit";
+  if (input.preserveOrder ?? true) {
+    return orderRecordsByInputIds(records, input.recordIds, notFound);
   }
 
-  return fetchRecords(input.offset, input.limit, input.signal);
+  if (notFound === "throw") {
+    const foundIds = new Set<string>(
+      records.flatMap((record) => {
+        const recordId = extractRecordId(record);
+        return recordId ? [recordId] : [];
+      }),
+    );
+    const missing = input.recordIds.filter(
+      (recordId) => !foundIds.has(recordId),
+    );
+    if (missing.length > 0) {
+      throw missingRecordsError(missing);
+    }
+  }
+
+  return records;
 }
 
 export type {
   InferRecordType,
   MatchingAttribute,
-  RecordId,
   RecordCreateInput,
+  RecordGetInput,
+  RecordGetManyInput,
+  RecordGetManyNotFoundPolicy,
+  RecordId,
   RecordObjectId,
   RecordQueryBaseInput,
   RecordQueryCollectInput,
@@ -324,10 +448,9 @@ export type {
   RecordQueryPaginationInput,
   RecordQuerySingleInput,
   RecordQueryStreamInput,
+  RecordSorts,
   RecordUpdateInput,
   RecordUpsertInput,
-  RecordGetInput,
-  RecordSorts,
   RecordValues,
 };
 export {
@@ -335,9 +458,13 @@ export {
   createRecord,
   createRecordId,
   createRecordObjectId,
+  deleteRecord,
+  getManyRecords,
+  getRecord,
+  matchingAttributeSchema,
+  queryRecords,
+  recordIdSchema,
+  recordObjectIdSchema,
   updateRecord,
   upsertRecord,
-  getRecord,
-  deleteRecord,
-  queryRecords,
 };

--- a/src/attio/response.ts
+++ b/src/attio/response.ts
@@ -287,6 +287,7 @@ function toResult<T>(
   };
 }
 
+export type { AttioResult, ResultOptions, UnwrapItemsOptions, UnwrapOptions };
 export {
   assertOk,
   createSchemaError,
@@ -298,4 +299,3 @@ export {
   validateItemsArray,
   validateWithSchema,
 };
-export type { AttioResult, ResultOptions, UnwrapItemsOptions, UnwrapOptions };

--- a/src/attio/retry.ts
+++ b/src/attio/retry.ts
@@ -134,10 +134,10 @@ async function callWithRetry<T>(
 
 export type { RetryConfig };
 export {
-  DEFAULT_RETRY_CONFIG,
-  sleep,
   calculateRetryDelay,
-  isRetryableStatus,
-  isRetryableError,
   callWithRetry,
+  DEFAULT_RETRY_CONFIG,
+  isRetryableError,
+  isRetryableStatus,
+  sleep,
 };

--- a/src/attio/schema.ts
+++ b/src/attio/schema.ts
@@ -216,5 +216,5 @@ const createSchema = async (input: SchemaInput): Promise<AttioSchema> => {
   };
 };
 
-export type { AttributeAccessor, AttioSchema, SchemaInput };
+export type { AttioSchema, AttributeAccessor, SchemaInput };
 export { createSchema };

--- a/src/attio/sdk.ts
+++ b/src/attio/sdk.ts
@@ -1,11 +1,16 @@
+import type { ZodType } from "zod";
 import type { AttioClient, AttioClientInput } from "./client";
 import { resolveAttioClient } from "./client";
+import type { AttioClientConfig } from "./config";
 import {
   type AddListEntryInput,
   addListEntry,
   type GetListInput,
   getList,
+  type ListQueryCollectInput,
   type ListQueryInput,
+  type ListQuerySingleInput,
+  type ListQueryStreamInput,
   listLists,
   queryListEntries,
   type RemoveListEntryInput,
@@ -14,11 +19,15 @@ import {
   updateListEntry,
 } from "./lists";
 import {
+  type AttributeFindInput,
   type AttributeInput,
   type AttributeListInput,
+  findAttribute,
   getAttribute,
   getAttributeOptions,
   getAttributeStatuses,
+  type ListAllowedValuesInput,
+  listAllowedValues,
   listAttributes,
 } from "./metadata";
 import {
@@ -31,14 +40,20 @@ import {
   type UpdateObjectInput,
   updateObject,
 } from "./objects";
+import type { AttioRecordLike } from "./record-utils";
 import {
   createRecord,
   deleteRecord,
+  getManyRecords,
   getRecord,
   queryRecords,
   type RecordCreateInput,
   type RecordGetInput,
+  type RecordGetManyInput,
+  type RecordQueryCollectInput,
   type RecordQueryInput,
+  type RecordQuerySingleInput,
+  type RecordQueryStreamInput,
   type RecordUpdateInput,
   type RecordUpsertInput,
   updateRecord,
@@ -47,10 +62,49 @@ import {
 import { createSchema, type SchemaInput } from "./schema";
 
 /** Helper type to omit client and config from input types for SDK methods */
-type SdkInput<T> = Omit<T, "client" | "config">;
+type SdkInput<T> = T extends unknown ? Omit<T, "client" | "config"> : never;
 
 /** Type alias for delete record input (same shape as RecordGetInput) */
 type RecordDeleteInput = RecordGetInput;
+
+type AttioSdkInput = AttioClientInput | AttioClientConfig;
+
+interface SdkRecordQuery {
+  <T extends AttioRecordLike>(
+    input: SdkInput<RecordQueryStreamInput<T>> & { itemSchema: ZodType<T> },
+  ): AsyncIterable<T>;
+  (input: SdkInput<RecordQueryStreamInput>): AsyncIterable<AttioRecordLike>;
+  <T extends AttioRecordLike>(
+    input: SdkInput<RecordQuerySingleInput<T> | RecordQueryCollectInput<T>> & {
+      itemSchema: ZodType<T>;
+    },
+  ): Promise<T[]>;
+  (
+    input: SdkInput<RecordQuerySingleInput | RecordQueryCollectInput>,
+  ): Promise<AttioRecordLike[]>;
+}
+
+interface SdkListQueryEntries {
+  <T extends AttioRecordLike>(
+    input: SdkInput<ListQueryStreamInput<T>> & { itemSchema: ZodType<T> },
+  ): AsyncIterable<T>;
+  (input: SdkInput<ListQueryStreamInput>): AsyncIterable<AttioRecordLike>;
+  <T extends AttioRecordLike>(
+    input: SdkInput<ListQuerySingleInput<T> | ListQueryCollectInput<T>> & {
+      itemSchema: ZodType<T>;
+    },
+  ): Promise<T[]>;
+  (
+    input: SdkInput<ListQuerySingleInput | ListQueryCollectInput>,
+  ): Promise<AttioRecordLike[]>;
+}
+
+interface SdkGetManyRecords {
+  <T extends AttioRecordLike>(
+    input: SdkInput<RecordGetManyInput<T>> & { itemSchema: ZodType<T> },
+  ): Promise<T[]>;
+  (input: SdkInput<RecordGetManyInput>): Promise<AttioRecordLike[]>;
+}
 
 interface AttioSdk {
   client: AttioClient;
@@ -77,19 +131,16 @@ interface AttioSdk {
       input: SdkInput<RecordUpsertInput>,
     ) => ReturnType<typeof upsertRecord>;
     get: (input: SdkInput<RecordGetInput>) => ReturnType<typeof getRecord>;
+    getMany: SdkGetManyRecords;
     delete: (
       input: SdkInput<RecordDeleteInput>,
     ) => ReturnType<typeof deleteRecord>;
-    query: (
-      input: SdkInput<RecordQueryInput>,
-    ) => ReturnType<typeof queryRecords>;
+    query: SdkRecordQuery;
   };
   lists: {
     list: (input?: SdkInput<AttioClientInput>) => ReturnType<typeof listLists>;
     get: (input: SdkInput<GetListInput>) => ReturnType<typeof getList>;
-    queryEntries: (
-      input: SdkInput<ListQueryInput>,
-    ) => ReturnType<typeof queryListEntries>;
+    queryEntries: SdkListQueryEntries;
     addEntry: (
       input: SdkInput<AddListEntryInput>,
     ) => ReturnType<typeof addListEntry>;
@@ -104,6 +155,9 @@ interface AttioSdk {
     listAttributes: (
       input: SdkInput<AttributeListInput>,
     ) => ReturnType<typeof listAttributes>;
+    findAttribute: (
+      input: SdkInput<AttributeFindInput>,
+    ) => ReturnType<typeof findAttribute>;
     getAttribute: (
       input: SdkInput<AttributeInput>,
     ) => ReturnType<typeof getAttribute>;
@@ -113,12 +167,86 @@ interface AttioSdk {
     getAttributeStatuses: (
       input: SdkInput<AttributeInput>,
     ) => ReturnType<typeof getAttributeStatuses>;
+    listAllowedValues: (
+      input: SdkInput<ListAllowedValuesInput>,
+    ) => ReturnType<typeof listAllowedValues>;
     schema: (input: SdkInput<SchemaInput>) => ReturnType<typeof createSchema>;
   };
 }
 
-const createAttioSdk = (input: AttioClientInput = {}): AttioSdk => {
-  const client = resolveAttioClient(input);
+const isAttioClientInput = (input: AttioSdkInput): input is AttioClientInput =>
+  "client" in input || "config" in input;
+
+const normalizeSdkInput = (input: AttioSdkInput): AttioClientInput => {
+  if (isAttioClientInput(input)) {
+    return input;
+  }
+  return { config: input };
+};
+
+function bindRecordQuery(client: AttioClient): SdkRecordQuery {
+  function query<T extends AttioRecordLike>(
+    input: SdkInput<RecordQueryStreamInput<T>> & { itemSchema: ZodType<T> },
+  ): AsyncIterable<T>;
+  function query(
+    input: SdkInput<RecordQueryStreamInput>,
+  ): AsyncIterable<AttioRecordLike>;
+  function query<T extends AttioRecordLike>(
+    input: SdkInput<RecordQuerySingleInput<T> | RecordQueryCollectInput<T>> & {
+      itemSchema: ZodType<T>;
+    },
+  ): Promise<T[]>;
+  function query(
+    input: SdkInput<RecordQuerySingleInput | RecordQueryCollectInput>,
+  ): Promise<AttioRecordLike[]>;
+  function query(
+    input: SdkInput<RecordQueryInput>,
+  ): Promise<AttioRecordLike[]> | AsyncIterable<AttioRecordLike> {
+    return queryRecords({ ...input, client });
+  }
+  return query;
+}
+
+function bindListQueryEntries(client: AttioClient): SdkListQueryEntries {
+  function queryEntries<T extends AttioRecordLike>(
+    input: SdkInput<ListQueryStreamInput<T>> & { itemSchema: ZodType<T> },
+  ): AsyncIterable<T>;
+  function queryEntries(
+    input: SdkInput<ListQueryStreamInput>,
+  ): AsyncIterable<AttioRecordLike>;
+  function queryEntries<T extends AttioRecordLike>(
+    input: SdkInput<ListQuerySingleInput<T> | ListQueryCollectInput<T>> & {
+      itemSchema: ZodType<T>;
+    },
+  ): Promise<T[]>;
+  function queryEntries(
+    input: SdkInput<ListQuerySingleInput | ListQueryCollectInput>,
+  ): Promise<AttioRecordLike[]>;
+  function queryEntries(
+    input: SdkInput<ListQueryInput>,
+  ): Promise<AttioRecordLike[]> | AsyncIterable<AttioRecordLike> {
+    return queryListEntries({ ...input, client });
+  }
+  return queryEntries;
+}
+
+function bindGetManyRecords(client: AttioClient): SdkGetManyRecords {
+  function getMany<T extends AttioRecordLike>(
+    input: SdkInput<RecordGetManyInput<T>> & { itemSchema: ZodType<T> },
+  ): Promise<T[]>;
+  function getMany(
+    input: SdkInput<RecordGetManyInput>,
+  ): Promise<AttioRecordLike[]>;
+  function getMany(
+    input: SdkInput<RecordGetManyInput>,
+  ): Promise<AttioRecordLike[]> {
+    return getManyRecords({ ...input, client });
+  }
+  return getMany;
+}
+
+const createAttioSdk = (input: AttioSdkInput = {}): AttioSdk => {
+  const client = resolveAttioClient(normalizeSdkInput(input));
 
   return {
     client,
@@ -133,28 +261,39 @@ const createAttioSdk = (input: AttioClientInput = {}): AttioSdk => {
       update: (params) => updateRecord({ ...params, client }),
       upsert: (params) => upsertRecord({ ...params, client }),
       get: (params) => getRecord({ ...params, client }),
+      getMany: bindGetManyRecords(client),
       delete: (params) => deleteRecord({ ...params, client }),
-      query: (params) => queryRecords({ ...params, client }),
+      query: bindRecordQuery(client),
     },
     lists: {
       list: (params = {}) => listLists({ ...params, client }),
       get: (params) => getList({ ...params, client }),
-      queryEntries: (params) => queryListEntries({ ...params, client }),
+      queryEntries: bindListQueryEntries(client),
       addEntry: (params) => addListEntry({ ...params, client }),
       updateEntry: (params) => updateListEntry({ ...params, client }),
       removeEntry: (params) => removeListEntry({ ...params, client }),
     },
     metadata: {
       listAttributes: (params) => listAttributes({ ...params, client }),
+      findAttribute: (params) => findAttribute({ ...params, client }),
       getAttribute: (params) => getAttribute({ ...params, client }),
       getAttributeOptions: (params) =>
         getAttributeOptions({ ...params, client }),
       getAttributeStatuses: (params) =>
         getAttributeStatuses({ ...params, client }),
+      listAllowedValues: (params) => listAllowedValues({ ...params, client }),
       schema: (params) => createSchema({ ...params, client }),
     },
   };
 };
 
-export type { AttioSdk, RecordDeleteInput, SdkInput };
+export type {
+  AttioSdk,
+  AttioSdkInput,
+  RecordDeleteInput,
+  SdkGetManyRecords,
+  SdkInput,
+  SdkListQueryEntries,
+  SdkRecordQuery,
+};
 export { createAttioSdk };

--- a/src/attio/tasks.ts
+++ b/src/attio/tasks.ts
@@ -16,7 +16,7 @@ import {
 } from "../generated";
 import { zTask } from "../generated/zod.gen";
 import { type AttioClientInput, resolveAttioClient } from "./client";
-import { type BrandedId, createBrandedId } from "./ids";
+import { type BrandedId, createBrandedIdSchema } from "./ids";
 import { callAndUnwrapData, callAndUnwrapItems } from "./operations";
 
 type Task = z.infer<typeof zTask>;
@@ -25,8 +25,9 @@ type TaskId = BrandedId<"TaskId">;
 type TaskCreateData = PostV2TasksData["body"]["data"];
 type TaskUpdateData = PatchV2TasksByTaskIdData["body"]["data"];
 
-const createTaskId = (id: string): TaskId =>
-  createBrandedId<"TaskId">(id, "TaskId");
+const taskIdSchema = createBrandedIdSchema<"TaskId">("TaskId");
+
+const createTaskId = (id: string): TaskId => taskIdSchema.parse(id);
 
 export interface TaskCreateInput extends AttioClientInput {
   data: TaskCreateData;
@@ -105,5 +106,5 @@ export const deleteTask = async (
   return result.data ?? {};
 };
 
-export { createTaskId };
 export type { TaskCreateData, TaskId, TaskUpdateData };
+export { createTaskId, taskIdSchema };

--- a/src/attio/value-schemas.ts
+++ b/src/attio/value-schemas.ts
@@ -181,6 +181,28 @@ const valueSchemasByType = {
 
 type ValueAttributeType = keyof typeof valueSchemasByType;
 
+export type {
+  ActorReferenceValue,
+  CheckboxValue,
+  CurrencyValue,
+  DateValue,
+  DomainValue,
+  EmailValue,
+  EnrichedSelectValue,
+  EnrichedStatusValue,
+  InteractionValue,
+  LocationValue,
+  NumberValue,
+  PersonalNameValue,
+  PhoneValue,
+  RatingValue,
+  RecordReferenceValue,
+  SelectValue,
+  StatusValue,
+  TextValue,
+  TimestampValue,
+  ValueAttributeType,
+};
 export {
   actorReferenceValueSchema,
   checkboxValueSchema,
@@ -204,27 +226,4 @@ export {
   textValueSchema,
   timestampValueSchema,
   valueSchemasByType,
-};
-
-export type {
-  ActorReferenceValue,
-  CheckboxValue,
-  CurrencyValue,
-  DateValue,
-  DomainValue,
-  EmailValue,
-  EnrichedSelectValue,
-  EnrichedStatusValue,
-  InteractionValue,
-  LocationValue,
-  NumberValue,
-  PersonalNameValue,
-  PhoneValue,
-  RatingValue,
-  RecordReferenceValue,
-  SelectValue,
-  StatusValue,
-  TextValue,
-  TimestampValue,
-  ValueAttributeType,
 };

--- a/src/attio/values.ts
+++ b/src/attio/values.ts
@@ -8,10 +8,12 @@ import {
   dateValueSchema,
   domainValueSchema,
   emailValueSchema,
+  locationValueSchema,
   numberValueSchema,
   personalNameValueSchema,
   phoneValueSchema,
   ratingValueSchema,
+  recordReferenceValueSchema,
   selectValueSchema,
   statusValueSchema,
   textValueSchema,
@@ -23,14 +25,67 @@ interface ValueCurrencyInput {
   currency_code?: string;
 }
 
-type ValueInput = InputValue | ValueCurrencyInput;
+interface ValuePhoneInput {
+  original_phone_number: string;
+  country_code?: string;
+}
+
+interface ValuePersonalNameInput {
+  first_name?: string;
+  last_name?: string;
+  full_name?: string;
+}
+
+interface ValueRecordReferenceInput {
+  targetObject: string;
+  targetRecordId: string;
+}
+
+interface ValueLocationInput {
+  line1?: string | null;
+  line2?: string | null;
+  line3?: string | null;
+  line4?: string | null;
+  locality?: string | null;
+  region?: string | null;
+  postcode?: string | null;
+  countryCode?: string | null;
+  latitude?: string | null;
+  longitude?: string | null;
+}
+
+interface ValueLocationPayload {
+  line_1: string | null;
+  line_2: string | null;
+  line_3: string | null;
+  line_4: string | null;
+  locality: string | null;
+  region: string | null;
+  postcode: string | null;
+  country_code: string | null;
+  latitude: string | null;
+  longitude: string | null;
+}
+
+type ValueInput =
+  | InputValue
+  | ValueCurrencyInput
+  | ValueLocationPayload
+  | ValuePhoneInput;
 
 interface ValueFactory {
   string: (value: string) => ValueInput[];
+  text: (value: string) => ValueInput[];
   number: (value: number) => ValueInput[];
   boolean: (value: boolean) => ValueInput[];
   domain: (value: string) => ValueInput[];
   email: (value: string) => ValueInput[];
+  phone: (value: string, countryCode?: string) => ValueInput[];
+  personalName: (input: ValuePersonalNameInput) => ValueInput[];
+  status: (value: string) => ValueInput[];
+  select: (value: string) => ValueInput[];
+  recordReference: (input: ValueRecordReferenceInput) => ValueInput[];
+  location: (input: ValueLocationInput) => ValueInput[];
   currency: (value: number, currencyCode?: string) => ValueInput[];
 }
 
@@ -43,16 +98,83 @@ const emailSchema = z.string().email("Expected a valid email address.");
 const currencyCodeSchema = z
   .string()
   .regex(/^[A-Z]{3}$/, "Expected ISO 4217 currency code.");
+const countryCodeSchema = z
+  .string()
+  .regex(/^[A-Z]{2}$/, "Expected ISO 3166-1 alpha-2 country code.");
 const finiteNumberSchema = z.number().finite("Expected a finite number.");
+const personalNameInputSchema = z
+  .object({
+    first_name: nonEmptyStringSchema.optional(),
+    last_name: nonEmptyStringSchema.optional(),
+    full_name: nonEmptyStringSchema.optional(),
+  })
+  .refine((input) => Object.values(input).some(Boolean), {
+    message: "Expected at least one name field.",
+  });
+const recordReferenceInputSchema = z.object({
+  targetObject: nonEmptyStringSchema,
+  targetRecordId: nonEmptyStringSchema,
+});
+const locationInputSchema = z.object({
+  line1: z.string().nullable().optional(),
+  line2: z.string().nullable().optional(),
+  line3: z.string().nullable().optional(),
+  line4: z.string().nullable().optional(),
+  locality: z.string().nullable().optional(),
+  region: z.string().nullable().optional(),
+  postcode: z.string().nullable().optional(),
+  countryCode: countryCodeSchema.nullable().optional(),
+  latitude: z.string().nullable().optional(),
+  longitude: z.string().nullable().optional(),
+});
 
 const wrapSingle = (input: ValueInput): ValueInput[] => [input];
 
 const value: ValueFactory = {
   string: (input) => wrapSingle({ value: nonEmptyStringSchema.parse(input) }),
+  text: (input) => wrapSingle({ value: nonEmptyStringSchema.parse(input) }),
   number: (input) => wrapSingle({ value: finiteNumberSchema.parse(input) }),
   boolean: (input) => wrapSingle({ value: z.boolean().parse(input) }),
   domain: (input) => wrapSingle({ domain: nonEmptyStringSchema.parse(input) }),
   email: (input) => wrapSingle({ email_address: emailSchema.parse(input) }),
+  phone: (input, countryCode) => {
+    const original_phone_number = nonEmptyStringSchema.parse(input);
+    if (countryCode === undefined) {
+      return wrapSingle({ original_phone_number });
+    }
+    return wrapSingle({
+      original_phone_number,
+      country_code: countryCodeSchema.parse(countryCode),
+    });
+  },
+  personalName: (input) => {
+    const parsed = personalNameInputSchema.parse(input);
+    return wrapSingle(parsed);
+  },
+  status: (input) => wrapSingle({ status: nonEmptyStringSchema.parse(input) }),
+  select: (input) => wrapSingle({ option: nonEmptyStringSchema.parse(input) }),
+  recordReference: (input) => {
+    const parsed = recordReferenceInputSchema.parse(input);
+    return wrapSingle({
+      target_object: parsed.targetObject,
+      target_record_id: parsed.targetRecordId,
+    });
+  },
+  location: (input) => {
+    const parsed = locationInputSchema.parse(input);
+    return wrapSingle({
+      line_1: parsed.line1 ?? null,
+      line_2: parsed.line2 ?? null,
+      line_3: parsed.line3 ?? null,
+      line_4: parsed.line4 ?? null,
+      locality: parsed.locality ?? null,
+      region: parsed.region ?? null,
+      postcode: parsed.postcode ?? null,
+      country_code: parsed.countryCode ?? null,
+      latitude: parsed.latitude ?? null,
+      longitude: parsed.longitude ?? null,
+    });
+  },
   currency: (input, currencyCode) => {
     const currency_value = finiteNumberSchema.parse(input);
     if (currencyCode === undefined) {
@@ -212,6 +334,19 @@ const extractFirstScalar = <T, R>(
   return extract(result.value);
 };
 
+const extractScalars = <T, R>(
+  record: AttioRecordLike,
+  attribute: string,
+  schema: z.ZodType<T>,
+  extract: (parsed: T) => R,
+): R[] | undefined => {
+  const result = getValueSafe(record, attribute, schema);
+  if (!result.ok || result.value === undefined) {
+    return;
+  }
+  return result.value.map(extract);
+};
+
 const getFirstText = (
   record: AttioRecordLike,
   attribute: string,
@@ -314,31 +449,96 @@ const getFirstPhone = (
     (v) => v.phone_number,
   );
 
+const getEmails = (
+  record: AttioRecordLike,
+  attribute: string,
+): string[] | undefined =>
+  extractScalars(record, attribute, emailValueSchema, (v) => v.email_address);
+
+const getPhones = (
+  record: AttioRecordLike,
+  attribute: string,
+): string[] | undefined =>
+  extractScalars(record, attribute, phoneValueSchema, (v) => v.phone_number);
+
+const getSelectTitles = (
+  record: AttioRecordLike,
+  attribute: string,
+): string[] | undefined =>
+  extractScalars(record, attribute, selectValueSchema, (v) =>
+    typeof v.option === "string" ? v.option : v.option.title,
+  );
+
+const getStatusTitles = (
+  record: AttioRecordLike,
+  attribute: string,
+): string[] | undefined =>
+  extractScalars(record, attribute, statusValueSchema, (v) =>
+    typeof v.status === "string" ? v.status : v.status.title,
+  );
+
+const getRecordReferenceIds = (
+  record: AttioRecordLike,
+  attribute: string,
+): string[] | undefined =>
+  extractScalars(
+    record,
+    attribute,
+    recordReferenceValueSchema,
+    (v) => v.target_record_id,
+  );
+
+const getFirstRecordReferenceId = (
+  record: AttioRecordLike,
+  attribute: string,
+): string | undefined =>
+  extractFirstScalar(
+    record,
+    attribute,
+    recordReferenceValueSchema,
+    (v) => v.target_record_id,
+  );
+
+const getFirstLocation = (record: AttioRecordLike, attribute: string) =>
+  extractFirstScalar(record, attribute, locationValueSchema, (v) => v);
+
+export type {
+  ValueCurrencyInput,
+  ValueErrorCode,
+  ValueFactory,
+  ValueInput,
+  ValueLocationInput,
+  ValueLocationPayload,
+  ValueLookupOptions,
+  ValuePersonalNameInput,
+  ValuePhoneInput,
+  ValueRecordReferenceInput,
+  ValueResult,
+};
 export {
+  getEmails,
   getFirstCheckbox,
   getFirstCurrencyValue,
   getFirstDate,
   getFirstDomain,
   getFirstEmail,
   getFirstFullName,
+  getFirstLocation,
   getFirstNumber,
   getFirstPhone,
   getFirstRating,
+  getFirstRecordReferenceId,
   getFirstSelectTitle,
   getFirstStatusTitle,
   getFirstText,
   getFirstTimestamp,
   getFirstValue,
   getFirstValueSafe,
+  getPhones,
+  getRecordReferenceIds,
+  getSelectTitles,
+  getStatusTitles,
   getValue,
   getValueSafe,
   value,
-};
-export type {
-  ValueErrorCode,
-  ValueCurrencyInput,
-  ValueFactory,
-  ValueInput,
-  ValueLookupOptions,
-  ValueResult,
 };

--- a/src/attio/workspace-members.ts
+++ b/src/attio/workspace-members.ts
@@ -3,20 +3,23 @@ import {
   getV2WorkspaceMembersByWorkspaceMemberId,
 } from "../generated";
 import type { AttioClientInput } from "./client";
-import { type BrandedId, createBrandedId } from "./ids";
+import { type BrandedId, createBrandedIdSchema } from "./ids";
 import { callAndUnwrapData, callAndUnwrapItems } from "./operations";
 
 type WorkspaceMemberId = BrandedId<"WorkspaceMemberId">;
 
+const workspaceMemberIdSchema =
+  createBrandedIdSchema<"WorkspaceMemberId">("WorkspaceMemberId");
+
 const createWorkspaceMemberId = (id: string): WorkspaceMemberId =>
-  createBrandedId<"WorkspaceMemberId">(id, "WorkspaceMemberId");
+  workspaceMemberIdSchema.parse(id);
 
 interface WorkspaceMemberInput extends AttioClientInput {
   workspaceMemberId: WorkspaceMemberId;
 }
 
-export { createWorkspaceMemberId };
 export type { WorkspaceMemberId };
+export { createWorkspaceMemberId, workspaceMemberIdSchema };
 
 export const listWorkspaceMembers = async (input: AttioClientInput = {}) =>
   callAndUnwrapItems(input, (client) => getV2WorkspaceMembers({ client }));

--- a/test/attio/errors.spec.ts
+++ b/test/attio/errors.spec.ts
@@ -9,6 +9,10 @@ import {
   AttioNetworkError,
   AttioResponseError,
   AttioRetryError,
+  getAttioErrorStatus,
+  isAttioError,
+  isAttioNotFound,
+  isRetryableAttioError,
   normalizeAttioError,
 } from "../../src/attio/errors";
 
@@ -321,5 +325,47 @@ describe("AttioError cause", () => {
   it("does not set cause when not provided", () => {
     const error = new AttioError("no cause");
     expect(error.cause).toBeUndefined();
+  });
+});
+
+describe("stable error helpers", () => {
+  it("narrows Attio errors without requiring instanceof", () => {
+    expect(isAttioError(new AttioError("boom"))).toBe(true);
+    expect(
+      isAttioError({
+        name: "AttioApiError",
+        message: "not found",
+        status: 404,
+      }),
+    ).toBe(true);
+    expect(isAttioError({ name: "Error", message: "plain" })).toBe(false);
+  });
+
+  it("extracts status from normalized and response-shaped errors", () => {
+    expect(
+      getAttioErrorStatus(new AttioApiError("missing", { status: 404 })),
+    ).toBe(404);
+    expect(getAttioErrorStatus({ response: { status: 429 } })).toBe(429);
+    expect(getAttioErrorStatus({ status_code: 422 })).toBe(422);
+  });
+
+  it("detects not found errors", () => {
+    expect(isAttioNotFound({ name: "AttioApiError", status: 404 })).toBe(true);
+    expect(isAttioNotFound({ name: "AttioApiError", status: 400 })).toBe(false);
+  });
+
+  it("detects retryable Attio failures", () => {
+    expect(isRetryableAttioError({ name: "AttioApiError", status: 429 })).toBe(
+      true,
+    );
+    expect(
+      isRetryableAttioError({
+        name: "AttioNetworkError",
+        isNetworkError: true,
+      }),
+    ).toBe(true);
+    expect(isRetryableAttioError({ name: "AttioApiError", status: 400 })).toBe(
+      false,
+    );
   });
 });

--- a/test/attio/filters.spec.ts
+++ b/test/attio/filters.spec.ts
@@ -294,6 +294,50 @@ describe("filters", () => {
     });
   });
 
+  describe("relationship and list helpers", () => {
+    it("builds a parent record id path filter", () => {
+      expect(
+        filters.parentRecordId({
+          list: "hiring-pipeline",
+          object: "people",
+          recordId: "rec-123",
+        }),
+      ).toEqual({
+        path: [
+          ["hiring-pipeline", "parent_record"],
+          ["people", "record_id"],
+        ],
+        constraints: { value: "rec-123" },
+      });
+    });
+
+    it("builds a parent record contains path filter", () => {
+      expect(
+        filters.parentRecordContains({
+          list: "hiring-pipeline",
+          object: "people",
+          attribute: "email_addresses",
+          field: "email_domain",
+          value: "example.com",
+        }),
+      ).toEqual({
+        path: [
+          ["hiring-pipeline", "parent_record"],
+          ["people", "email_addresses"],
+        ],
+        constraints: { email_domain: { $contains: "example.com" } },
+      });
+    });
+
+    it("builds a nested list status filter", () => {
+      expect(
+        filters.listStatus({ attribute: "stage", status: "Interview" }),
+      ).toEqual({
+        stage: { status: { $eq: "Interview" } },
+      });
+    });
+  });
+
   describe("attioFilterSchema", () => {
     it("parses valid filters", () => {
       const filter = {

--- a/test/attio/ids.spec.ts
+++ b/test/attio/ids.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { createBrandedId } from "../../src/attio/ids";
+import { createBrandedId, createBrandedIdSchema } from "../../src/attio/ids";
 
 describe("ids", () => {
   it("creates branded IDs from non-empty values", () => {
@@ -14,5 +14,13 @@ describe("ids", () => {
     expect(() => createBrandedId<"CustomId">("   ", "CustomId")).toThrow(
       "CustomId cannot be empty",
     );
+  });
+
+  it("creates reusable branded ID schemas", () => {
+    const schema = createBrandedIdSchema<"CustomId">("CustomId");
+
+    expect(schema.parse("id-123")).toBe("id-123");
+    expect(() => schema.parse("")).toThrow();
+    expect(() => schema.parse("   ")).toThrow();
   });
 });

--- a/test/attio/lists.spec.ts
+++ b/test/attio/lists.spec.ts
@@ -74,6 +74,7 @@ describe("lists", () => {
   let createEntryId: typeof import("../../src/attio/lists").createEntryId;
   let createParentObjectId: typeof import("../../src/attio/lists").createParentObjectId;
   let createParentRecordId: typeof import("../../src/attio/lists").createParentRecordId;
+  let listIdSchema: typeof import("../../src/attio/lists").listIdSchema;
   let filters: typeof import("../../src/attio/filters").filters;
 
   beforeAll(async () => {
@@ -88,6 +89,7 @@ describe("lists", () => {
       createEntryId,
       createParentObjectId,
       createParentRecordId,
+      listIdSchema,
     } = await import("../../src/attio/lists"));
     ({ filters } = await import("../../src/attio/filters"));
   });
@@ -106,6 +108,11 @@ describe("lists", () => {
 
     it("throws error when id is empty string", () => {
       expect(() => createListId("")).toThrow("ListId cannot be empty");
+    });
+
+    it("exports a branded ListId schema", () => {
+      expect(listIdSchema.parse("list-123")).toBe("list-123");
+      expect(() => listIdSchema.parse("")).toThrow();
     });
   });
 

--- a/test/attio/metadata.spec.ts
+++ b/test/attio/metadata.spec.ts
@@ -8,9 +8,11 @@ import {
   buildAttributeMetadataPath,
   buildKey,
   extractTitles,
+  findAttribute,
   getAttribute,
   getAttributeOptions,
   getAttributeStatuses,
+  listAllowedValues,
   listAttributeMetadata,
   listAttributes,
 } from "../../src/attio/metadata";
@@ -359,6 +361,121 @@ describe("metadata", () => {
 
       const input = buildInput("status");
       await expect(getAttributeStatuses(input)).rejects.toThrow();
+    });
+  });
+
+  describe("findAttribute", () => {
+    it("finds an attribute by slug, title, and type", async () => {
+      const listMock = vi.mocked(getV2ByTargetByIdentifierAttributes);
+      const attributes = [
+        createMockAttribute({ api_slug: "name", title: "Name", type: "text" }),
+        createMockAttribute({
+          api_slug: "stage",
+          title: "Stage",
+          type: "status",
+        }),
+      ];
+      listMock.mockResolvedValue({ data: { data: attributes } });
+
+      const result = await findAttribute({
+        target: "objects",
+        identifier: "companies",
+        slug: "stage",
+        title: "Stage",
+        type: "status",
+        config: { apiKey },
+      });
+
+      expect(result).toEqual(attributes[1]);
+    });
+
+    it("returns undefined when no attribute matches", async () => {
+      const listMock = vi.mocked(getV2ByTargetByIdentifierAttributes);
+      listMock.mockResolvedValue({
+        data: { data: [createMockAttribute({ api_slug: "name" })] },
+      });
+
+      const result = await findAttribute({
+        target: "objects",
+        identifier: "companies",
+        slug: "missing",
+        config: { apiKey },
+      });
+
+      expect(result).toBeUndefined();
+    });
+
+    it("requires at least one find criterion", async () => {
+      await expect(
+        findAttribute({
+          target: "objects",
+          identifier: "companies",
+          config: { apiKey },
+        }),
+      ).rejects.toMatchObject({ code: "MISSING_ATTRIBUTE_CRITERIA" });
+    });
+  });
+
+  describe("listAllowedValues", () => {
+    it("normalizes select options", async () => {
+      const optionsMock = vi.mocked(
+        getV2ByTargetByIdentifierAttributesByAttributeOptions,
+      );
+      optionsMock.mockResolvedValue({
+        data: [
+          createMockSelectOption({
+            title: "Enterprise",
+            is_archived: true,
+          }),
+        ],
+      });
+
+      const result = await listAllowedValues({
+        ...buildInput("segment"),
+        type: "select",
+      });
+
+      expect(result).toEqual([
+        {
+          id: "550e8400-e29b-41d4-a716-446655440003",
+          title: "Enterprise",
+          archived: true,
+        },
+      ]);
+    });
+
+    it("normalizes statuses after resolving attribute type", async () => {
+      const getMock = vi.mocked(getV2ByTargetByIdentifierAttributesByAttribute);
+      const statusesMock = vi.mocked(
+        getV2ByTargetByIdentifierAttributesByAttributeStatuses,
+      );
+      getMock.mockResolvedValue({
+        data: createMockAttribute({ api_slug: "stage", type: "status" }),
+      });
+      statusesMock.mockResolvedValue({
+        data: [createMockStatus({ title: "Active" })],
+      });
+
+      const result = await listAllowedValues(buildInput("stage"));
+
+      expect(result).toEqual([
+        {
+          id: "550e8400-e29b-41d4-a716-446655440004",
+          title: "Active",
+          archived: false,
+        },
+      ]);
+    });
+
+    it("rejects attributes without allowed values", async () => {
+      const getMock = vi.mocked(getV2ByTargetByIdentifierAttributesByAttribute);
+      getMock.mockResolvedValue({
+        data: createMockAttribute({ api_slug: "name", type: "text" }),
+      });
+
+      await expect(listAllowedValues(buildInput("name"))).rejects.toMatchObject(
+        { code: "UNSUPPORTED_ATTRIBUTE_TYPE" },
+      );
     });
   });
 

--- a/test/attio/records.spec.ts
+++ b/test/attio/records.spec.ts
@@ -29,6 +29,9 @@ vi.mock("../../src/attio/client", () => ({
 }));
 
 vi.mock("../../src/attio/record-utils", () => ({
+  extractRecordId: vi.fn((record: { id?: { record_id?: string } | string }) =>
+    typeof record.id === "string" ? record.id : record.id?.record_id,
+  ),
   normalizeRecord: vi.fn((record) => record),
   normalizeRecords: vi.fn((records) => records),
 }));
@@ -38,11 +41,13 @@ describe("records", () => {
   let updateRecord: typeof import("../../src/attio/records").updateRecord;
   let upsertRecord: typeof import("../../src/attio/records").upsertRecord;
   let getRecord: typeof import("../../src/attio/records").getRecord;
+  let getManyRecords: typeof import("../../src/attio/records").getManyRecords;
   let deleteRecord: typeof import("../../src/attio/records").deleteRecord;
   let queryRecords: typeof import("../../src/attio/records").queryRecords;
   let createRecordObjectId: typeof import("../../src/attio/records").createRecordObjectId;
   let createRecordId: typeof import("../../src/attio/records").createRecordId;
   let createMatchingAttribute: typeof import("../../src/attio/records").createMatchingAttribute;
+  let recordIdSchema: typeof import("../../src/attio/records").recordIdSchema;
   let filters: typeof import("../../src/attio/filters").filters;
 
   beforeAll(async () => {
@@ -51,11 +56,13 @@ describe("records", () => {
       updateRecord,
       upsertRecord,
       getRecord,
+      getManyRecords,
       deleteRecord,
       queryRecords,
       createRecordObjectId,
       createRecordId,
       createMatchingAttribute,
+      recordIdSchema,
     } = await import("../../src/attio/records"));
     ({ filters } = await import("../../src/attio/filters"));
   });
@@ -80,6 +87,11 @@ describe("records", () => {
       expect(() => createMatchingAttribute("")).toThrow(
         "MatchingAttribute cannot be empty",
       );
+    });
+
+    it("exports branded ID schemas", () => {
+      expect(recordIdSchema.parse("rec-123")).toBe("rec-123");
+      expect(() => recordIdSchema.parse("")).toThrow();
     });
   });
 
@@ -435,6 +447,77 @@ describe("records", () => {
       });
 
       expect(result).toBe(true);
+    });
+  });
+
+  describe("getManyRecords", () => {
+    it("returns an empty array without calling API for empty input", async () => {
+      const result = await getManyRecords({
+        object: "companies",
+        recordIds: [],
+      });
+
+      expect(result).toEqual([]);
+      expect(queryRecordsRequest).not.toHaveBeenCalled();
+    });
+
+    it("queries IDs in chunks and preserves input order", async () => {
+      queryRecordsRequest
+        .mockResolvedValueOnce({
+          data: {
+            data: [
+              { id: { record_id: "rec-2" }, values: {} },
+              { id: { record_id: "rec-1" }, values: {} },
+            ],
+          },
+        })
+        .mockResolvedValueOnce({
+          data: {
+            data: [{ id: { record_id: "rec-3" }, values: {} }],
+          },
+        });
+
+      const result = await getManyRecords({
+        object: "companies",
+        recordIds: ["rec-1", "rec-2", "rec-3"],
+        chunkSize: 2,
+        concurrency: 1,
+      });
+
+      expect(result.map((record) => record.id)).toEqual([
+        { record_id: "rec-1" },
+        { record_id: "rec-2" },
+        { record_id: "rec-3" },
+      ]);
+      expect(queryRecordsRequest).toHaveBeenCalledTimes(2);
+      expect(queryRecordsRequest).toHaveBeenNthCalledWith(1, {
+        client: {},
+        path: { object: "companies" },
+        body: {
+          filter: { record_id: { $in: ["rec-1", "rec-2"] } },
+          limit: 2,
+          offset: 0,
+        },
+        signal: expect.any(AbortSignal),
+      });
+    });
+
+    it("throws when requested records are missing and notFound is throw", async () => {
+      queryRecordsRequest.mockResolvedValue({
+        data: {
+          data: [{ id: { record_id: "rec-1" }, values: {} }],
+        },
+      });
+
+      await expect(
+        getManyRecords({
+          object: "companies",
+          recordIds: ["rec-1", "rec-missing"],
+          notFound: "throw",
+        }),
+      ).rejects.toMatchObject({
+        code: "RECORDS_NOT_FOUND",
+      });
     });
   });
 

--- a/test/attio/sdk.spec.ts
+++ b/test/attio/sdk.spec.ts
@@ -1,5 +1,8 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, expectTypeOf, it, vi } from "vitest";
+import { z } from "zod";
 import { createAttioClient } from "../../src/attio/client";
+import type { ListId } from "../../src/attio/lists";
+import type { RecordObjectId } from "../../src/attio/records";
 import { createAttioSdk } from "../../src/attio/sdk";
 
 const mocks = vi.hoisted(() => ({
@@ -14,6 +17,7 @@ const mocks = vi.hoisted(() => ({
     updateRecord: vi.fn().mockResolvedValue({}),
     upsertRecord: vi.fn().mockResolvedValue({}),
     getRecord: vi.fn().mockResolvedValue({}),
+    getManyRecords: vi.fn().mockResolvedValue([]),
     deleteRecord: vi.fn().mockResolvedValue(true),
     queryRecords: vi.fn().mockResolvedValue([]),
   },
@@ -80,6 +84,7 @@ describe("createAttioSdk", () => {
       values: {},
     });
     await sdk.records.get({ object: "companies", recordId: "rec_1" });
+    await sdk.records.getMany({ object: "companies", recordIds: ["rec_1"] });
     await sdk.records.delete({ object: "companies", recordId: "rec_1" });
     await sdk.records.query({ object: "companies" });
 
@@ -153,6 +158,11 @@ describe("createAttioSdk", () => {
       client,
       object: "companies",
       recordId: "rec_1",
+    });
+    expect(mocks.records.getManyRecords).toHaveBeenCalledWith({
+      client,
+      object: "companies",
+      recordIds: ["rec_1"],
     });
     expect(mocks.records.deleteRecord).toHaveBeenCalledWith({
       client,
@@ -278,5 +288,62 @@ describe("createAttioSdk", () => {
         pluralNoun: "Deals",
       }),
     ).rejects.toThrow("API Error");
+  });
+
+  it("accepts flat client config", async () => {
+    const mockFetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ data: {} }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    const sdk = createAttioSdk({
+      apiKey: "attio_test_token_12345",
+      fetch: mockFetch,
+    });
+
+    expect(sdk.client.getConfig().auth).toBe("attio_test_token_12345");
+  });
+
+  it("preserves query overload inference on namespaced methods", () => {
+    const mockFetch: typeof fetch = () =>
+      Promise.resolve(
+        new Response(JSON.stringify({ data: {} }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+    const client = createAttioClient({
+      authToken: "attio_test_token_12345",
+      fetch: mockFetch,
+    });
+    const sdk = createAttioSdk({ client });
+    const object = "companies" as RecordObjectId;
+    const list = "sales-pipeline" as ListId;
+    const itemSchema = z.object({
+      id: z.object({ record_id: z.string() }),
+      values: z.object({ name: z.array(z.object({ value: z.string() })) }),
+    });
+    type Item = z.infer<typeof itemSchema>;
+
+    expectTypeOf(
+      sdk.records.query({ object, paginate: false, itemSchema }),
+    ).toEqualTypeOf<Promise<Item[]>>();
+    expectTypeOf(
+      sdk.records.query({ object, paginate: true, itemSchema }),
+    ).toEqualTypeOf<Promise<Item[]>>();
+    expectTypeOf(
+      sdk.records.query({ object, paginate: "stream", itemSchema }),
+    ).toEqualTypeOf<AsyncIterable<Item>>();
+    expectTypeOf(
+      sdk.lists.queryEntries({ list, paginate: false, itemSchema }),
+    ).toEqualTypeOf<Promise<Item[]>>();
+    expectTypeOf(
+      sdk.lists.queryEntries({ list, paginate: true, itemSchema }),
+    ).toEqualTypeOf<Promise<Item[]>>();
+    expectTypeOf(
+      sdk.lists.queryEntries({ list, paginate: "stream", itemSchema }),
+    ).toEqualTypeOf<AsyncIterable<Item>>();
   });
 });

--- a/test/attio/tasks.spec.ts
+++ b/test/attio/tasks.spec.ts
@@ -16,6 +16,7 @@ const createMockTask = (overrides: Partial<Task> = {}): Task => ({
   content_plaintext: "Test task content",
   deadline_at: null,
   is_completed: false,
+  completed_at: null,
   linked_records: [],
   assignees: [],
   created_by_actor: {

--- a/test/attio/values.spec.ts
+++ b/test/attio/values.spec.ts
@@ -2,21 +2,28 @@ import { describe, expect, it } from "vitest";
 import { z } from "zod";
 import { AttioResponseError } from "../../src/attio/errors";
 import {
+  getEmails,
   getFirstCheckbox,
   getFirstCurrencyValue,
   getFirstDate,
   getFirstDomain,
   getFirstEmail,
   getFirstFullName,
+  getFirstLocation,
   getFirstNumber,
   getFirstPhone,
   getFirstRating,
+  getFirstRecordReferenceId,
   getFirstSelectTitle,
   getFirstStatusTitle,
   getFirstText,
   getFirstTimestamp,
   getFirstValue,
   getFirstValueSafe,
+  getPhones,
+  getRecordReferenceIds,
+  getSelectTitles,
+  getStatusTitles,
   getValue,
   getValueSafe,
   value,
@@ -44,6 +51,49 @@ describe("value helpers", () => {
       { email_address: "hello@example.com" },
     ]);
     expect(value.currency(123)).toEqual([{ currency_value: 123 }]);
+  });
+
+  it("builds richer typed values", () => {
+    expect(value.text("hello")).toEqual([{ value: "hello" }]);
+    expect(value.phone("+15551234567")).toEqual([
+      { original_phone_number: "+15551234567" },
+    ]);
+    expect(value.phone("5551234567", "US")).toEqual([
+      { original_phone_number: "5551234567", country_code: "US" },
+    ]);
+    expect(value.personalName({ full_name: "Jane Doe" })).toEqual([
+      { full_name: "Jane Doe" },
+    ]);
+    expect(value.status("Active")).toEqual([{ status: "Active" }]);
+    expect(value.select("Enterprise")).toEqual([{ option: "Enterprise" }]);
+    expect(
+      value.recordReference({
+        targetObject: "companies",
+        targetRecordId: "rec-123",
+      }),
+    ).toEqual([{ target_object: "companies", target_record_id: "rec-123" }]);
+    expect(value.location({ locality: "Oakland", countryCode: "US" })).toEqual([
+      {
+        line_1: null,
+        line_2: null,
+        line_3: null,
+        line_4: null,
+        locality: "Oakland",
+        region: null,
+        postcode: null,
+        country_code: "US",
+        latitude: null,
+        longitude: null,
+      },
+    ]);
+  });
+
+  it("validates richer typed values", () => {
+    expect(() => value.phone("5551234567", "USA")).toThrow();
+    expect(() => value.personalName({})).toThrow();
+    expect(() =>
+      value.recordReference({ targetObject: "", targetRecordId: "rec-123" }),
+    ).toThrow();
   });
 });
 
@@ -172,6 +222,40 @@ describe("typed primitive getters", () => {
       phone: [
         { original_phone_number: "+15551234567", phone_number: "+15551234567" },
       ],
+      emails: [
+        {
+          original_email_address: "a@example.com",
+          email_address: "a@example.com",
+        },
+        {
+          original_email_address: "b@example.com",
+          email_address: "b@example.com",
+        },
+      ],
+      phones: [
+        { original_phone_number: "+15550000001", phone_number: "+15550000001" },
+        { original_phone_number: "+15550000002", phone_number: "+15550000002" },
+      ],
+      stages: [{ option: { title: "Seed" } }, { option: "opt_2" }],
+      statuses: [{ status: { title: "Open" } }, { status: "sta_2" }],
+      company: [
+        { target_object: "companies", target_record_id: "company-1" },
+        { target_object: "companies", target_record_id: "company-2" },
+      ],
+      office: [
+        {
+          line_1: "1 Market St",
+          line_2: null,
+          line_3: null,
+          line_4: null,
+          locality: "San Francisco",
+          region: "CA",
+          postcode: "94105",
+          country_code: "US",
+          latitude: null,
+          longitude: null,
+        },
+      ],
     },
   };
 
@@ -235,6 +319,31 @@ describe("typed primitive getters", () => {
 
   it("getFirstPhone extracts phone_number", () => {
     expect(getFirstPhone(record, "phone")).toBe("+15551234567");
+  });
+
+  it("plural readers extract common scalar values", () => {
+    expect(getEmails(record, "emails")).toEqual([
+      "a@example.com",
+      "b@example.com",
+    ]);
+    expect(getPhones(record, "phones")).toEqual([
+      "+15550000001",
+      "+15550000002",
+    ]);
+    expect(getSelectTitles(record, "stages")).toEqual(["Seed", "opt_2"]);
+    expect(getStatusTitles(record, "statuses")).toEqual(["Open", "sta_2"]);
+    expect(getRecordReferenceIds(record, "company")).toEqual([
+      "company-1",
+      "company-2",
+    ]);
+  });
+
+  it("record-reference and location readers extract first values", () => {
+    expect(getFirstRecordReferenceId(record, "company")).toBe("company-1");
+    expect(getFirstLocation(record, "office")).toMatchObject({
+      locality: "San Francisco",
+      country_code: "US",
+    });
   });
 
   it("returns undefined for missing attribute", () => {


### PR DESCRIPTION
- accept flat createAttioSdk config and preserve query overloads
- export branded ID schemas and add value/filter/error/metadata helpers
- add bulk record lookup and docs/type coverage

Model: GPT-5 Codex
Reasoning: medium
Thread: 019e2259-dbb8-76c3-a6d7-750f2534f6bb

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Expand Attio SDK with new value builders, record fetching, metadata helpers, and error utilities
> - Adds `value` factory methods for `text`, `phone`, `personalName`, `status`, `select`, `recordReference`, and `location`, each with input validation via Zod schemas
> - Adds getter helpers (`getEmails`, `getPhones`, `getSelectTitles`, `getStatusTitles`, `getRecordReferenceIds`, `getFirstRecordReferenceId`, `getFirstLocation`) to extract typed values from records
> - Adds `records.getMany` to the SDK for batched, concurrent fetching of records by ID with configurable `notFound` policy (`'omit'` or `'throw'`) and optional order preservation
> - Adds `metadata.findAttribute` and `metadata.listAllowedValues` to the SDK for attribute lookup and normalized select/status option retrieval
> - Adds error helpers `isAttioError`, `getAttioErrorStatus`, `isAttioNotFound`, and `isRetryableAttioError` to [src/attio/errors.ts](https://github.com/hbmartin/attio-ts-sdk/pull/147/files#diff-04f0a9359a4656765ea144a17d039c333e7c22700e807dbbcdcdb4ea13301b12)
> - Adds filter helpers `parentRecordId`, `parentRecordContains`, and `listStatus` to [src/attio/filters.ts](https://github.com/hbmartin/attio-ts-sdk/pull/147/files#diff-2c72603cac6d167e2b0851738d3d3dc1d96d47cb59f3bab27a143f1fc180583d)
> - Replaces `createBrandedId` calls with Zod-based schemas across ID helper modules; empty strings now throw a `ZodError` at ID creation time
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 49ab840.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bulk record retrieval with `getManyRecords` supporting concurrent queries and optional result reordering.
  * Introduced relationship and status filtering helpers (`parentRecordId`, `listStatus`).
  * Added metadata helpers for finding attributes by criteria and listing allowed values.
  * Extended value parsing with phone, location, and personal name support.
  * Expanded value readers for extracting emails, phones, select/status titles, and record references.

* **Bug Fixes & Improvements**
  * Improved error handling with stable helper functions for type-checking and retry logic.
  * Enhanced SDK query method overloads and pagination support.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hbmartin/attio-ts-sdk/pull/147)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->