### PR TITLE
feat: expand sdk ergonomics for notes and tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,10 @@ The returned `sdk` object exposes these namespaces:
 | `sdk.objects` | `list`, `get`, `create`, `update` |
 | `sdk.records` | `create`, `update`, `upsert`, `get`, `getMany`, `delete`, `query` |
 | `sdk.lists` | `list`, `get`, `queryEntries`, `addEntry`, `updateEntry`, `removeEntry` |
+| `sdk.notes` | `list`, `get`, `create`, `delete` |
+| `sdk.tasks` | `list`, `get`, `create`, `update`, `delete` |
+| `sdk.search` | `records` |
+| `sdk.workspaceMembers` | `list`, `get` |
 | `sdk.metadata` | `listAttributes`, `findAttribute`, `getAttribute`, `getAttributeOptions`, `getAttributeStatuses`, `listAllowedValues`, `schema` |
 
 The underlying `AttioClient` is also available as `sdk.client` when you need to drop down to the generated endpoints.
@@ -622,8 +626,8 @@ For more control or when working directly with generated endpoints, use `paginat
 
 | Strategy | Helper | Endpoints |
 | --- | --- | --- |
-| **Offset-based** | `paginateOffset` | Record queries (`postV2ObjectsByObjectRecordsQuery`), list entry queries (`postV2ListsByListEntriesQuery`) |
-| **Cursor-based** | `paginate` | Meetings (`getV2Meetings`), notes (`getV2Notes`), tasks (`getV2Tasks`), webhooks, and most `GET` list endpoints |
+| **Offset-based** | `paginateOffset` | Record queries (`postV2ObjectsByObjectRecordsQuery`), list entry queries (`postV2ListsByListEntriesQuery`), notes (`getV2Notes`), tasks (`getV2Tasks`) |
+| **Cursor-based** | `paginate` | Meetings (`getV2Meetings`), webhooks, and most `GET` list endpoints |
 
 Both helpers automatically extract items and pagination metadata from raw API responses.
 
@@ -1000,99 +1004,77 @@ const { data: entry } = await postV2ListsByListEntries({
 ### Notes and Tasks
 
 ```typescript
-import { postV2Notes, postV2Tasks, patchV2TasksByTaskId } from 'attio-ts-sdk';
+import { createAttioSdk } from 'attio-ts-sdk';
 
-// Create a note on a record
-const { data: note } = await postV2Notes({
-  client,
-  body: {
-    data: {
-      parent_object: 'companies',
-      parent_record_id: 'abc-123',
-      title: 'Meeting Notes',
-      content: 'Discussed Q4 roadmap...',
-    },
+const sdk = createAttioSdk({ apiKey: process.env.ATTIO_API_KEY });
+
+// Create a note on a record.
+const note = await sdk.notes.create({
+  parentObject: 'companies',
+  parentRecordId: 'abc-123',
+  title: 'Meeting Notes',
+  format: 'markdown',
+  content: 'Discussed Q4 roadmap...',
+});
+
+// Create a task.
+const task = await sdk.tasks.create({
+  data: {
+    content: 'Follow up on proposal',
+    format: 'plaintext',
+    deadline_at: '2024-12-31T17:00:00Z',
+    is_completed: false,
+    linked_records: [{ target_object: 'companies', target_record_id: 'abc-123' }],
+    assignees: [],
   },
 });
 
-// Create a task
-const { data: task } = await postV2Tasks({
-  client,
-  body: {
-    data: {
-      content: 'Follow up on proposal',
-      deadline_at: '2024-12-31T17:00:00Z',
-      linked_records: [{ target_object: 'companies', target_record_id: 'abc-123' }],
-    },
-  },
-});
-
-// Mark task as complete
-await patchV2TasksByTaskId({
-  client,
-  path: { task_id: task.data.id.task_id },
-  body: { data: { is_completed: true } },
+// Mark task as complete.
+await sdk.tasks.update({
+  taskId: task.id.task_id,
+  data: { is_completed: true },
 });
 ```
 
 ### Listing and Viewing Person Notes
 
-Use `getV2Notes` with `parent_object: 'people'` and the person's record ID to list notes attached to a specific person. The notes API uses offset pagination, so keep requesting pages until the API returns fewer than the requested limit.
+Use `sdk.notes.list` with `parentObject: 'people'` and the person's record ID to list notes attached to a specific person. Set `paginate: true` to collect every page, or `paginate: 'stream'` to iterate notes lazily.
 
 ```typescript
-import type { Note } from 'attio-ts-sdk';
-import {
-  assertOk,
-  createAttioClient,
-  getV2Notes,
-  getV2NotesByNoteId,
-} from 'attio-ts-sdk';
+import { createAttioSdk } from 'attio-ts-sdk';
 
-const client = createAttioClient({ apiKey: process.env.ATTIO_API_KEY });
+const sdk = createAttioSdk({ apiKey: process.env.ATTIO_API_KEY });
 const personRecordId = 'person-record-id';
 
-const listPersonNotes = async (recordId: string): Promise<Note[]> => {
-  const limit = 50;
-  const notes: Note[] = [];
-
-  for (let offset = 0; ; offset += limit) {
-    const page = assertOk(
-      await getV2Notes({
-        client,
-        query: {
-          parent_object: 'people',
-          parent_record_id: recordId,
-          limit,
-          offset,
-        },
-      }),
-    );
-
-    notes.push(...page.data);
-
-    if (page.data.length < limit) {
-      return notes;
-    }
-  }
-};
-
-const personNotes = await listPersonNotes(personRecordId);
+const personNotes = await sdk.notes.list({
+  parentObject: 'people',
+  parentRecordId: personRecordId,
+  paginate: true,
+  limit: 50,
+});
 
 const firstNote = personNotes[0];
 if (firstNote) {
-  const note = assertOk(
-    await getV2NotesByNoteId({
-      client,
-      path: { note_id: firstNote.id.note_id },
-    }),
-  );
+  const note = await sdk.notes.get({ noteId: firstNote.id.note_id });
 
-  console.log(note.data.title);
-  console.log(note.data.content_markdown ?? note.data.content_plaintext);
+  console.log(note.title);
+  console.log(note.content_markdown ?? note.content_plaintext);
 }
 ```
 
 The integration token needs `note:read`, `object_configuration:read`, and `record_permission:read` scopes for these reads.
+
+The task wrapper exposes the generated list filters as camelCase inputs:
+
+```typescript
+const openTasksForPerson = await sdk.tasks.list({
+  linkedRecord: { object: 'people', recordId: personRecordId },
+  assignee: 'owner@example.com',
+  isCompleted: false,
+  sort: 'created_at:desc',
+  paginate: true,
+});
+```
 
 ### Webhooks
 

--- a/src/attio/notes.ts
+++ b/src/attio/notes.ts
@@ -2,6 +2,7 @@ import type { z } from "zod";
 import type {
   DeleteV2NotesByNoteIdData,
   GetV2NotesByNoteIdData,
+  GetV2NotesData,
   Options,
   PostV2NotesData,
 } from "../generated";
@@ -12,13 +13,11 @@ import {
   postV2Notes,
 } from "../generated";
 import { zNote } from "../generated/zod.gen";
-import type { AttioClientInput } from "./client";
+import { type AttioClientInput, resolveAttioClient } from "./client";
 import { type BrandedId, createBrandedIdSchema } from "./ids";
-import {
-  callAndDelete,
-  callAndUnwrapData,
-  callAndUnwrapItems,
-} from "./operations";
+import { callAndDelete, callAndUnwrapData } from "./operations";
+import { resolveOffsetItems } from "./pagination";
+import { unwrapItems } from "./response";
 
 type Note = z.infer<typeof zNote>;
 
@@ -26,6 +25,7 @@ type NoteId = BrandedId<"NoteId">;
 type NoteParentObjectId = BrandedId<"NoteParentObjectId">;
 type NoteParentRecordId = BrandedId<"NoteParentRecordId">;
 type NoteFormat = PostV2NotesData["body"]["data"]["format"];
+type NoteListQuery = NonNullable<GetV2NotesData["query"]>;
 
 const noteIdSchema = createBrandedIdSchema<"NoteId">("NoteId");
 const noteParentObjectIdSchema = createBrandedIdSchema<"NoteParentObjectId">(
@@ -41,7 +41,7 @@ const createNoteParentObjectId = (id: string): NoteParentObjectId =>
 const createNoteParentRecordId = (id: string): NoteParentRecordId =>
   noteParentRecordIdSchema.parse(id);
 
-export interface NoteCreateInput extends AttioClientInput {
+interface NoteCreateInput extends AttioClientInput {
   parentObject: NoteParentObjectId;
   parentRecordId: NoteParentRecordId;
   title: string;
@@ -52,22 +52,93 @@ export interface NoteCreateInput extends AttioClientInput {
   options?: Omit<Options<PostV2NotesData>, "client" | "body">;
 }
 
-export interface NoteGetInput extends AttioClientInput {
+interface NoteGetInput extends AttioClientInput {
   noteId: NoteId;
   options?: Omit<Options<GetV2NotesByNoteIdData>, "client" | "path">;
 }
 
-export interface NoteDeleteInput extends AttioClientInput {
+interface NoteDeleteInput extends AttioClientInput {
   noteId: NoteId;
   options?: Omit<Options<DeleteV2NotesByNoteIdData>, "client" | "path">;
 }
 
-export const listNotes = async (
-  input: AttioClientInput = {},
-): Promise<Note[]> =>
-  callAndUnwrapItems(input, (client) => getV2Notes({ client }), {
-    schema: zNote,
-  });
+interface NoteListBaseInput extends AttioClientInput {
+  parentObject?: NoteListQuery["parent_object"];
+  parentRecordId?: NoteListQuery["parent_record_id"];
+  limit?: NoteListQuery["limit"];
+  offset?: NoteListQuery["offset"];
+  signal?: AbortSignal;
+  options?: Omit<Options<GetV2NotesData>, "client" | "query">;
+}
+
+interface NoteListSingleInput extends NoteListBaseInput {
+  paginate?: false;
+}
+
+interface NoteListCollectInput extends NoteListBaseInput {
+  paginate: true;
+  maxPages?: number;
+  maxItems?: number;
+}
+
+interface NoteListStreamInput extends NoteListBaseInput {
+  paginate: "stream";
+  maxPages?: number;
+  maxItems?: number;
+}
+
+type NoteListInput =
+  | NoteListSingleInput
+  | NoteListCollectInput
+  | NoteListStreamInput;
+
+const hasDefinedQueryValue = (query: NoteListQuery): boolean =>
+  Object.values(query).some((value) => value !== undefined);
+
+const buildNoteListQuery = (
+  input: NoteListBaseInput,
+  offset?: number,
+  limit?: number,
+): NoteListQuery | undefined => {
+  const query: NoteListQuery = {
+    limit,
+    offset,
+    parent_object: input.parentObject,
+    parent_record_id: input.parentRecordId,
+  };
+
+  return hasDefinedQueryValue(query) ? query : undefined;
+};
+
+export function listNotes(input: NoteListStreamInput): AsyncIterable<Note>;
+export function listNotes(
+  input?: NoteListSingleInput | NoteListCollectInput,
+): Promise<Note[]>;
+export function listNotes(
+  input: NoteListInput,
+): Promise<Note[]> | AsyncIterable<Note>;
+export function listNotes(
+  input: NoteListInput = {},
+): Promise<Note[]> | AsyncIterable<Note> {
+  const client = resolveAttioClient(input);
+
+  const fetchNotes = async (
+    offset?: number,
+    limit?: number,
+    signal?: AbortSignal,
+  ): Promise<Note[]> => {
+    const result = await getV2Notes({
+      client,
+      query: buildNoteListQuery(input, offset, limit),
+      ...input.options,
+      signal,
+    });
+
+    return unwrapItems<Note>(result, { schema: zNote });
+  };
+
+  return resolveOffsetItems(fetchNotes, input);
+}
 
 export const getNote = async (input: NoteGetInput): Promise<Note> =>
   callAndUnwrapData(
@@ -112,7 +183,20 @@ export const deleteNote = async (input: NoteDeleteInput): Promise<true> =>
     }),
   );
 
-export type { NoteFormat, NoteId, NoteParentObjectId, NoteParentRecordId };
+export type {
+  NoteCreateInput,
+  NoteDeleteInput,
+  NoteFormat,
+  NoteGetInput,
+  NoteId,
+  NoteListBaseInput,
+  NoteListCollectInput,
+  NoteListInput,
+  NoteListSingleInput,
+  NoteListStreamInput,
+  NoteParentObjectId,
+  NoteParentRecordId,
+};
 export {
   createNoteId,
   createNoteParentObjectId,

--- a/src/attio/sdk.ts
+++ b/src/attio/sdk.ts
@@ -31,6 +31,19 @@ import {
   listAttributes,
 } from "./metadata";
 import {
+  createNote,
+  deleteNote,
+  getNote,
+  listNotes,
+  type NoteCreateInput,
+  type NoteDeleteInput,
+  type NoteGetInput,
+  type NoteListCollectInput,
+  type NoteListInput,
+  type NoteListSingleInput,
+  type NoteListStreamInput,
+} from "./notes";
+import {
   type CreateObjectInput,
   createObject,
   type GetObjectInput,
@@ -60,6 +73,27 @@ import {
   upsertRecord,
 } from "./records";
 import { createSchema, type SchemaInput } from "./schema";
+import { type RecordSearchInput, searchRecords } from "./search";
+import {
+  createTask,
+  deleteTask,
+  getTask,
+  listTasks,
+  type TaskCreateInput,
+  type TaskDeleteInput,
+  type TaskGetInput,
+  type TaskListCollectInput,
+  type TaskListInput,
+  type TaskListSingleInput,
+  type TaskListStreamInput,
+  type TaskUpdateInput,
+  updateTask,
+} from "./tasks";
+import {
+  getWorkspaceMember,
+  listWorkspaceMembers,
+  type WorkspaceMemberInput,
+} from "./workspace-members";
 
 /** Helper type to omit client and config from input types for SDK methods */
 type SdkInput<T> = T extends unknown ? Omit<T, "client" | "config"> : never;
@@ -68,6 +102,8 @@ type SdkInput<T> = T extends unknown ? Omit<T, "client" | "config"> : never;
 type RecordDeleteInput = RecordGetInput;
 
 type AttioSdkInput = AttioClientInput | AttioClientConfig;
+type SdkNote = Awaited<ReturnType<typeof getNote>>;
+type SdkTask = Awaited<ReturnType<typeof getTask>>;
 
 interface SdkRecordQuery {
   <T extends AttioRecordLike>(
@@ -104,6 +140,27 @@ interface SdkGetManyRecords {
     input: SdkInput<RecordGetManyInput<T>> & { itemSchema: ZodType<T> },
   ): Promise<T[]>;
   (input: SdkInput<RecordGetManyInput>): Promise<AttioRecordLike[]>;
+}
+
+interface SdkListNotes {
+  (input: SdkInput<NoteListStreamInput>): AsyncIterable<SdkNote>;
+  (
+    input?: SdkInput<NoteListSingleInput | NoteListCollectInput>,
+  ): Promise<SdkNote[]>;
+}
+
+interface SdkListTasks {
+  (input: SdkInput<TaskListStreamInput>): AsyncIterable<SdkTask>;
+  (
+    input?: SdkInput<TaskListSingleInput | TaskListCollectInput>,
+  ): Promise<SdkTask[]>;
+}
+
+interface SdkSearchRecords {
+  <T extends AttioRecordLike>(
+    input: SdkInput<RecordSearchInput<T>> & { itemSchema: ZodType<T> },
+  ): Promise<T[]>;
+  (input: SdkInput<RecordSearchInput>): Promise<AttioRecordLike[]>;
 }
 
 interface AttioSdk {
@@ -150,6 +207,30 @@ interface AttioSdk {
     removeEntry: (
       input: SdkInput<RemoveListEntryInput>,
     ) => ReturnType<typeof removeListEntry>;
+  };
+  notes: {
+    list: SdkListNotes;
+    get: (input: SdkInput<NoteGetInput>) => ReturnType<typeof getNote>;
+    create: (input: SdkInput<NoteCreateInput>) => ReturnType<typeof createNote>;
+    delete: (input: SdkInput<NoteDeleteInput>) => ReturnType<typeof deleteNote>;
+  };
+  tasks: {
+    list: SdkListTasks;
+    get: (input: SdkInput<TaskGetInput>) => ReturnType<typeof getTask>;
+    create: (input: SdkInput<TaskCreateInput>) => ReturnType<typeof createTask>;
+    update: (input: SdkInput<TaskUpdateInput>) => ReturnType<typeof updateTask>;
+    delete: (input: SdkInput<TaskDeleteInput>) => ReturnType<typeof deleteTask>;
+  };
+  search: {
+    records: SdkSearchRecords;
+  };
+  workspaceMembers: {
+    list: (
+      input?: SdkInput<AttioClientInput>,
+    ) => ReturnType<typeof listWorkspaceMembers>;
+    get: (
+      input: SdkInput<WorkspaceMemberInput>,
+    ) => ReturnType<typeof getWorkspaceMember>;
   };
   metadata: {
     listAttributes: (
@@ -245,6 +326,47 @@ function bindGetManyRecords(client: AttioClient): SdkGetManyRecords {
   return getMany;
 }
 
+function bindListNotes(client: AttioClient): SdkListNotes {
+  function list(input: SdkInput<NoteListStreamInput>): AsyncIterable<SdkNote>;
+  function list(
+    input?: SdkInput<NoteListSingleInput | NoteListCollectInput>,
+  ): Promise<SdkNote[]>;
+  function list(
+    input: SdkInput<NoteListInput> = {},
+  ): Promise<SdkNote[]> | AsyncIterable<SdkNote> {
+    return listNotes({ ...input, client });
+  }
+  return list;
+}
+
+function bindListTasks(client: AttioClient): SdkListTasks {
+  function list(input: SdkInput<TaskListStreamInput>): AsyncIterable<SdkTask>;
+  function list(
+    input?: SdkInput<TaskListSingleInput | TaskListCollectInput>,
+  ): Promise<SdkTask[]>;
+  function list(
+    input: SdkInput<TaskListInput> = {},
+  ): Promise<SdkTask[]> | AsyncIterable<SdkTask> {
+    return listTasks({ ...input, client });
+  }
+  return list;
+}
+
+function bindSearchRecords(client: AttioClient): SdkSearchRecords {
+  function records<T extends AttioRecordLike>(
+    input: SdkInput<RecordSearchInput<T>> & { itemSchema: ZodType<T> },
+  ): Promise<T[]>;
+  function records(
+    input: SdkInput<RecordSearchInput>,
+  ): Promise<AttioRecordLike[]>;
+  function records(
+    input: SdkInput<RecordSearchInput>,
+  ): Promise<AttioRecordLike[]> {
+    return searchRecords({ ...input, client });
+  }
+  return records;
+}
+
 const createAttioSdk = (input: AttioSdkInput = {}): AttioSdk => {
   const client = resolveAttioClient(normalizeSdkInput(input));
 
@@ -273,6 +395,26 @@ const createAttioSdk = (input: AttioSdkInput = {}): AttioSdk => {
       updateEntry: (params) => updateListEntry({ ...params, client }),
       removeEntry: (params) => removeListEntry({ ...params, client }),
     },
+    notes: {
+      list: bindListNotes(client),
+      get: (params) => getNote({ ...params, client }),
+      create: (params) => createNote({ ...params, client }),
+      delete: (params) => deleteNote({ ...params, client }),
+    },
+    tasks: {
+      list: bindListTasks(client),
+      get: (params) => getTask({ ...params, client }),
+      create: (params) => createTask({ ...params, client }),
+      update: (params) => updateTask({ ...params, client }),
+      delete: (params) => deleteTask({ ...params, client }),
+    },
+    search: {
+      records: bindSearchRecords(client),
+    },
+    workspaceMembers: {
+      list: (params = {}) => listWorkspaceMembers({ ...params, client }),
+      get: (params) => getWorkspaceMember({ ...params, client }),
+    },
     metadata: {
       listAttributes: (params) => listAttributes({ ...params, client }),
       findAttribute: (params) => findAttribute({ ...params, client }),
@@ -293,7 +435,10 @@ export type {
   RecordDeleteInput,
   SdkGetManyRecords,
   SdkInput,
+  SdkListNotes,
   SdkListQueryEntries,
+  SdkListTasks,
   SdkRecordQuery,
+  SdkSearchRecords,
 };
 export { createAttioSdk };

--- a/src/attio/tasks.ts
+++ b/src/attio/tasks.ts
@@ -3,6 +3,7 @@ import type {
   DeleteV2TasksByTaskIdData,
   DeleteV2TasksByTaskIdResponse,
   GetV2TasksByTaskIdData,
+  GetV2TasksData,
   Options,
   PatchV2TasksByTaskIdData,
   PostV2TasksData,
@@ -17,45 +18,130 @@ import {
 import { zTask } from "../generated/zod.gen";
 import { type AttioClientInput, resolveAttioClient } from "./client";
 import { type BrandedId, createBrandedIdSchema } from "./ids";
-import { callAndUnwrapData, callAndUnwrapItems } from "./operations";
+import { callAndUnwrapData } from "./operations";
+import { resolveOffsetItems } from "./pagination";
+import { unwrapItems } from "./response";
 
 type Task = z.infer<typeof zTask>;
 
 type TaskId = BrandedId<"TaskId">;
 type TaskCreateData = PostV2TasksData["body"]["data"];
 type TaskUpdateData = PatchV2TasksByTaskIdData["body"]["data"];
+type TaskListQuery = NonNullable<GetV2TasksData["query"]>;
+type TaskListSort = TaskListQuery["sort"];
+
+interface TaskLinkedRecordInput {
+  object: NonNullable<TaskListQuery["linked_object"]>;
+  recordId: NonNullable<TaskListQuery["linked_record_id"]>;
+}
 
 const taskIdSchema = createBrandedIdSchema<"TaskId">("TaskId");
 
 const createTaskId = (id: string): TaskId => taskIdSchema.parse(id);
 
-export interface TaskCreateInput extends AttioClientInput {
+interface TaskCreateInput extends AttioClientInput {
   data: TaskCreateData;
   options?: Omit<Options<PostV2TasksData>, "client" | "body">;
 }
 
-export interface TaskUpdateInput extends AttioClientInput {
+interface TaskUpdateInput extends AttioClientInput {
   taskId: TaskId;
   data: TaskUpdateData;
   options?: Omit<Options<PatchV2TasksByTaskIdData>, "client" | "path" | "body">;
 }
 
-export interface TaskDeleteInput extends AttioClientInput {
+interface TaskDeleteInput extends AttioClientInput {
   taskId: TaskId;
   options?: Omit<Options<DeleteV2TasksByTaskIdData>, "client" | "path">;
 }
 
-export interface TaskGetInput extends AttioClientInput {
+interface TaskGetInput extends AttioClientInput {
   taskId: TaskId;
   options?: Omit<Options<GetV2TasksByTaskIdData>, "client" | "path">;
 }
 
-export const listTasks = async (
-  input: AttioClientInput = {},
-): Promise<Task[]> =>
-  callAndUnwrapItems(input, (client) => getV2Tasks({ client }), {
-    schema: zTask,
-  });
+interface TaskListBaseInput extends AttioClientInput {
+  limit?: TaskListQuery["limit"];
+  offset?: TaskListQuery["offset"];
+  sort?: TaskListSort;
+  assignee?: TaskListQuery["assignee"];
+  isCompleted?: TaskListQuery["is_completed"];
+  linkedRecord?: TaskLinkedRecordInput;
+  signal?: AbortSignal;
+  options?: Omit<Options<GetV2TasksData>, "client" | "query">;
+}
+
+interface TaskListSingleInput extends TaskListBaseInput {
+  paginate?: false;
+}
+
+interface TaskListCollectInput extends TaskListBaseInput {
+  paginate: true;
+  maxPages?: number;
+  maxItems?: number;
+}
+
+interface TaskListStreamInput extends TaskListBaseInput {
+  paginate: "stream";
+  maxPages?: number;
+  maxItems?: number;
+}
+
+type TaskListInput =
+  | TaskListSingleInput
+  | TaskListCollectInput
+  | TaskListStreamInput;
+
+const hasDefinedQueryValue = (query: TaskListQuery): boolean =>
+  Object.values(query).some((value) => value !== undefined);
+
+const buildTaskListQuery = (
+  input: TaskListBaseInput,
+  offset?: number,
+  limit?: number,
+): TaskListQuery | undefined => {
+  const query: TaskListQuery = {
+    limit,
+    offset,
+    sort: input.sort,
+    linked_object: input.linkedRecord?.object,
+    linked_record_id: input.linkedRecord?.recordId,
+    assignee: input.assignee,
+    is_completed: input.isCompleted,
+  };
+
+  return hasDefinedQueryValue(query) ? query : undefined;
+};
+
+export function listTasks(input: TaskListStreamInput): AsyncIterable<Task>;
+export function listTasks(
+  input?: TaskListSingleInput | TaskListCollectInput,
+): Promise<Task[]>;
+export function listTasks(
+  input: TaskListInput,
+): Promise<Task[]> | AsyncIterable<Task>;
+export function listTasks(
+  input: TaskListInput = {},
+): Promise<Task[]> | AsyncIterable<Task> {
+  const client = resolveAttioClient(input);
+
+  const fetchTasks = async (
+    offset?: number,
+    limit?: number,
+    signal?: AbortSignal,
+  ): Promise<Task[]> => {
+    const result = await getV2Tasks({
+      client,
+      query: buildTaskListQuery(input, offset, limit),
+      ...input.options,
+      signal,
+    });
+
+    return unwrapItems<Task>(result, { schema: zTask });
+  };
+
+  return resolveOffsetItems(fetchTasks, input);
+}
 
 export const getTask = async (input: TaskGetInput): Promise<Task> =>
   callAndUnwrapData(
@@ -106,5 +192,20 @@ export const deleteTask = async (
   return result.data ?? {};
 };
 
-export type { TaskCreateData, TaskId, TaskUpdateData };
+export type {
+  TaskCreateData,
+  TaskCreateInput,
+  TaskDeleteInput,
+  TaskGetInput,
+  TaskId,
+  TaskLinkedRecordInput,
+  TaskListBaseInput,
+  TaskListCollectInput,
+  TaskListInput,
+  TaskListSingleInput,
+  TaskListSort,
+  TaskListStreamInput,
+  TaskUpdateData,
+  TaskUpdateInput,
+};
 export { createTaskId, taskIdSchema };

--- a/src/attio/workspace-members.ts
+++ b/src/attio/workspace-members.ts
@@ -18,7 +18,7 @@ interface WorkspaceMemberInput extends AttioClientInput {
   workspaceMemberId: WorkspaceMemberId;
 }
 
-export type { WorkspaceMemberId };
+export type { WorkspaceMemberId, WorkspaceMemberInput };
 export { createWorkspaceMemberId, workspaceMemberIdSchema };
 
 export const listWorkspaceMembers = async (input: AttioClientInput = {}) =>

--- a/test/attio/notes.spec.ts
+++ b/test/attio/notes.spec.ts
@@ -118,6 +118,80 @@ describe("notes", () => {
 
       expect(resolveAttioClient).toHaveBeenCalledWith({ apiKey: "test-key" });
     });
+
+    it("passes parent filters and pagination query parameters", async () => {
+      getNotesRequest.mockResolvedValue({ data: { data: [] } });
+
+      await listNotes({
+        parentObject: "people",
+        parentRecordId: "c3d4e5f6-a7b8-4c9d-ae0f-1a2b3c4d5e6f",
+        limit: 25,
+        offset: 50,
+        options: { headers: { "X-Custom": "value" } },
+      });
+
+      expect(getNotesRequest).toHaveBeenCalledWith({
+        client: {},
+        query: {
+          parent_object: "people",
+          parent_record_id: "c3d4e5f6-a7b8-4c9d-ae0f-1a2b3c4d5e6f",
+          limit: 25,
+          offset: 50,
+        },
+        headers: { "X-Custom": "value" },
+      });
+    });
+
+    it("collects all note pages when pagination is enabled", async () => {
+      const note1 = createMockNote({
+        id: {
+          workspace_id: "a1b2c3d4-e5f6-4a1b-8c2d-3e4f5a6b7c8d",
+          note_id: "11111111-1111-4111-8111-111111111111",
+        },
+      });
+      const note2 = createMockNote({
+        id: {
+          workspace_id: "a1b2c3d4-e5f6-4a1b-8c2d-3e4f5a6b7c8d",
+          note_id: "22222222-2222-4222-8222-222222222222",
+        },
+      });
+      const note3 = createMockNote({
+        id: {
+          workspace_id: "a1b2c3d4-e5f6-4a1b-8c2d-3e4f5a6b7c8d",
+          note_id: "33333333-3333-4333-8333-333333333333",
+        },
+      });
+      getNotesRequest
+        .mockResolvedValueOnce({ data: { data: [note1, note2] } })
+        .mockResolvedValueOnce({ data: { data: [note3] } });
+
+      const result = await listNotes({
+        parentObject: "people",
+        parentRecordId: "c3d4e5f6-a7b8-4c9d-ae0f-1a2b3c4d5e6f",
+        paginate: true,
+        limit: 2,
+      });
+
+      expect(result).toEqual([note1, note2, note3]);
+      expect(getNotesRequest).toHaveBeenNthCalledWith(1, {
+        client: {},
+        query: {
+          parent_object: "people",
+          parent_record_id: "c3d4e5f6-a7b8-4c9d-ae0f-1a2b3c4d5e6f",
+          limit: 2,
+          offset: 0,
+        },
+      });
+      expect(getNotesRequest).toHaveBeenNthCalledWith(2, {
+        client: {},
+        query: {
+          parent_object: "people",
+          parent_record_id: "c3d4e5f6-a7b8-4c9d-ae0f-1a2b3c4d5e6f",
+          limit: 2,
+          offset: 2,
+        },
+      });
+    });
   });
 
   describe("getNote", () => {

--- a/test/attio/sdk.spec.ts
+++ b/test/attio/sdk.spec.ts
@@ -29,6 +29,26 @@ const mocks = vi.hoisted(() => ({
     updateListEntry: vi.fn().mockResolvedValue({}),
     removeListEntry: vi.fn().mockResolvedValue(true),
   },
+  notes: {
+    listNotes: vi.fn().mockResolvedValue([]),
+    getNote: vi.fn().mockResolvedValue({}),
+    createNote: vi.fn().mockResolvedValue({}),
+    deleteNote: vi.fn().mockResolvedValue(true),
+  },
+  tasks: {
+    listTasks: vi.fn().mockResolvedValue([]),
+    getTask: vi.fn().mockResolvedValue({}),
+    createTask: vi.fn().mockResolvedValue({}),
+    updateTask: vi.fn().mockResolvedValue({}),
+    deleteTask: vi.fn().mockResolvedValue({}),
+  },
+  search: {
+    searchRecords: vi.fn().mockResolvedValue([]),
+  },
+  workspaceMembers: {
+    listWorkspaceMembers: vi.fn().mockResolvedValue([]),
+    getWorkspaceMember: vi.fn().mockResolvedValue({}),
+  },
   metadata: {
     listAttributes: vi.fn().mockResolvedValue([]),
     getAttribute: vi.fn().mockResolvedValue({}),
@@ -43,6 +63,10 @@ const mocks = vi.hoisted(() => ({
 vi.mock("../../src/attio/objects", () => mocks.objects);
 vi.mock("../../src/attio/records", () => mocks.records);
 vi.mock("../../src/attio/lists", () => mocks.lists);
+vi.mock("../../src/attio/notes", () => mocks.notes);
+vi.mock("../../src/attio/tasks", () => mocks.tasks);
+vi.mock("../../src/attio/search", () => mocks.search);
+vi.mock("../../src/attio/workspace-members", () => mocks.workspaceMembers);
 vi.mock("../../src/attio/metadata", () => mocks.metadata);
 vi.mock("../../src/attio/schema", () => mocks.schema);
 
@@ -98,6 +122,40 @@ describe("createAttioSdk", () => {
       entryValues: {},
     });
     await sdk.lists.removeEntry({ list: "list_1", entryId: "entry_1" });
+
+    await sdk.notes.list({ parentObject: "people", parentRecordId: "rec_1" });
+    await sdk.notes.get({ noteId: "note_1" });
+    await sdk.notes.create({
+      parentObject: "people",
+      parentRecordId: "rec_1",
+      title: "Intro call",
+      format: "plaintext",
+      content: "Discussed next steps.",
+    });
+    await sdk.notes.delete({ noteId: "note_1" });
+
+    await sdk.tasks.list({ isCompleted: false });
+    await sdk.tasks.get({ taskId: "task_1" });
+    await sdk.tasks.create({
+      data: {
+        content: "Follow up",
+        format: "plaintext",
+        deadline_at: null,
+        is_completed: false,
+        linked_records: [],
+        assignees: [],
+      },
+    });
+    await sdk.tasks.update({
+      taskId: "task_1",
+      data: { is_completed: true },
+    });
+    await sdk.tasks.delete({ taskId: "task_1" });
+
+    await sdk.search.records({ query: "acme", objects: ["companies"] });
+
+    await sdk.workspaceMembers.list();
+    await sdk.workspaceMembers.get({ workspaceMemberId: "member_1" });
 
     await sdk.metadata.listAttributes({
       target: "objects",
@@ -198,6 +256,71 @@ describe("createAttioSdk", () => {
       client,
       list: "list_1",
       entryId: "entry_1",
+    });
+
+    expect(mocks.notes.listNotes).toHaveBeenCalledWith({
+      client,
+      parentObject: "people",
+      parentRecordId: "rec_1",
+    });
+    expect(mocks.notes.getNote).toHaveBeenCalledWith({
+      client,
+      noteId: "note_1",
+    });
+    expect(mocks.notes.createNote).toHaveBeenCalledWith({
+      client,
+      parentObject: "people",
+      parentRecordId: "rec_1",
+      title: "Intro call",
+      format: "plaintext",
+      content: "Discussed next steps.",
+    });
+    expect(mocks.notes.deleteNote).toHaveBeenCalledWith({
+      client,
+      noteId: "note_1",
+    });
+
+    expect(mocks.tasks.listTasks).toHaveBeenCalledWith({
+      client,
+      isCompleted: false,
+    });
+    expect(mocks.tasks.getTask).toHaveBeenCalledWith({
+      client,
+      taskId: "task_1",
+    });
+    expect(mocks.tasks.createTask).toHaveBeenCalledWith({
+      client,
+      data: {
+        content: "Follow up",
+        format: "plaintext",
+        deadline_at: null,
+        is_completed: false,
+        linked_records: [],
+        assignees: [],
+      },
+    });
+    expect(mocks.tasks.updateTask).toHaveBeenCalledWith({
+      client,
+      taskId: "task_1",
+      data: { is_completed: true },
+    });
+    expect(mocks.tasks.deleteTask).toHaveBeenCalledWith({
+      client,
+      taskId: "task_1",
+    });
+
+    expect(mocks.search.searchRecords).toHaveBeenCalledWith({
+      client,
+      query: "acme",
+      objects: ["companies"],
+    });
+
+    expect(mocks.workspaceMembers.listWorkspaceMembers).toHaveBeenCalledWith({
+      client,
+    });
+    expect(mocks.workspaceMembers.getWorkspaceMember).toHaveBeenCalledWith({
+      client,
+      workspaceMemberId: "member_1",
     });
 
     expect(mocks.metadata.listAttributes).toHaveBeenCalledWith({
@@ -345,5 +468,8 @@ describe("createAttioSdk", () => {
     expectTypeOf(
       sdk.lists.queryEntries({ list, paginate: "stream", itemSchema }),
     ).toEqualTypeOf<AsyncIterable<Item>>();
+    expectTypeOf(
+      sdk.search.records({ query: "acme", objects: ["companies"], itemSchema }),
+    ).toEqualTypeOf<Promise<Item[]>>();
   });
 });

--- a/test/attio/tasks.spec.ts
+++ b/test/attio/tasks.spec.ts
@@ -103,6 +103,93 @@ describe("tasks", () => {
 
       expect(resolveAttioClient).toHaveBeenCalledWith({ apiKey: "test-key" });
     });
+
+    it("passes filters, sort, and pagination query parameters", async () => {
+      getTasksRequest.mockResolvedValue({ data: { data: [] } });
+
+      await listTasks({
+        limit: 100,
+        offset: 200,
+        sort: "completed_at:desc",
+        assignee: null,
+        isCompleted: true,
+        linkedRecord: {
+          object: "people",
+          recordId: "c3d4e5f6-a7b8-4c9d-ae0f-1a2b3c4d5e6f",
+        },
+        options: { headers: { "X-Custom": "value" } },
+      });
+
+      expect(getTasksRequest).toHaveBeenCalledWith({
+        client: {},
+        query: {
+          limit: 100,
+          offset: 200,
+          sort: "completed_at:desc",
+          linked_object: "people",
+          linked_record_id: "c3d4e5f6-a7b8-4c9d-ae0f-1a2b3c4d5e6f",
+          assignee: null,
+          is_completed: true,
+        },
+        headers: { "X-Custom": "value" },
+      });
+    });
+
+    it("collects all task pages when pagination is enabled", async () => {
+      const task1 = createMockTask({
+        id: {
+          workspace_id: "a1b2c3d4-e5f6-4a1b-8c2d-3e4f5a6b7c8d",
+          task_id: "11111111-1111-4111-8111-111111111111",
+        },
+      });
+      const task2 = createMockTask({
+        id: {
+          workspace_id: "a1b2c3d4-e5f6-4a1b-8c2d-3e4f5a6b7c8d",
+          task_id: "22222222-2222-4222-8222-222222222222",
+        },
+      });
+      const task3 = createMockTask({
+        id: {
+          workspace_id: "a1b2c3d4-e5f6-4a1b-8c2d-3e4f5a6b7c8d",
+          task_id: "33333333-3333-4333-8333-333333333333",
+        },
+      });
+      getTasksRequest
+        .mockResolvedValueOnce({ data: { data: [task1, task2] } })
+        .mockResolvedValueOnce({ data: { data: [task3] } });
+
+      const result = await listTasks({
+        paginate: true,
+        limit: 2,
+        isCompleted: false,
+      });
+
+      expect(result).toEqual([task1, task2, task3]);
+      expect(getTasksRequest).toHaveBeenNthCalledWith(1, {
+        client: {},
+        query: {
+          limit: 2,
+          offset: 0,
+          sort: undefined,
+          linked_object: undefined,
+          linked_record_id: undefined,
+          assignee: undefined,
+          is_completed: false,
+        },
+      });
+      expect(getTasksRequest).toHaveBeenNthCalledWith(2, {
+        client: {},
+        query: {
+          limit: 2,
+          offset: 2,
+          sort: undefined,
+          linked_object: undefined,
+          linked_record_id: undefined,
+          assignee: undefined,
+          is_completed: false,
+        },
+      });
+    });
   });
 
   describe("getTask", () => {


### PR DESCRIPTION
Added listNotes({ parentObject, parentRecordId, limit, offset, paginate }).
Added listTasks({ limit, offset, sort, assignee, isCompleted, linkedRecord, paginate }).
Added sdk.notes, sdk.tasks, sdk.search.records, and sdk.workspaceMembers.
Updated README examples to use the ergonomic SDK facade.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Expand SDK ergonomics by adding notes, tasks, search, and workspaceMembers namespaces to `createAttioSdk`
> - Wires `notes`, `tasks`, `search.records`, and `workspaceMembers` namespaces into the SDK object returned by `createAttioSdk` in [sdk.ts](https://github.com/hbmartin/attio-ts-sdk/pull/149/files#diff-527ac4af176136aab68db926036a0b48b3d792f1be77526f75fa44578b7886d5).
> - Replaces basic single-call wrappers in [notes.ts](https://github.com/hbmartin/attio-ts-sdk/pull/149/files#diff-3326eae130fe9e36e0684f3dd24f4dfb139b93017bc17f8559ce9568db8bdfd8) and [tasks.ts](https://github.com/hbmartin/attio-ts-sdk/pull/149/files#diff-2a67d23544783c714563f48d0c2f3afd8729b513b5d228b5e336b07d05b9fef3) with offset-based pagination supporting single-page, collect-all, and async-stream modes via overloads.
> - `listNotes` adds `parentObject`/`parentRecordId` filters; `listTasks` adds `sort`, `assignee`, `isCompleted`, and `linkedRecord` filters, all mapped from camelCase inputs to generated query fields.
> - Behavioral Change: callers using the old `listNotes`/`listTasks` wrappers directly get new default behavior (single-page mode); opt-in to `paginate:true` or `paginate:'stream'` for multi-page collection.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8137444.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `sdk.notes`, `sdk.tasks`, `sdk.search.records`, and `sdk.workspaceMembers` namespaces for streamlined API access.
  * Expanded list operations to support flexible pagination: single fetch, batch collection, and streaming iteration.

* **Documentation**
  * Updated README with new namespace methods and improved code examples using the convenience layer.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hbmartin/attio-ts-sdk/pull/149)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->