### PR TITLE
fix: address PR feedback on batching

### DIFF
--- a/src/attio/batch.ts
+++ b/src/attio/batch.ts
@@ -17,6 +17,7 @@ interface BatchResult<T> {
 interface BatchOptions {
   concurrency?: number;
   stopOnError?: boolean;
+  signal?: AbortSignal;
 }
 
 interface BatchState<T> {
@@ -72,7 +73,7 @@ const recordFailure = <T>(params: RecordFailureParams<T>): void => {
     if (!state.stopped) {
       state.stopped = true;
       if (abortController && !abortController.signal.aborted) {
-        abortController.abort();
+        abortController.abort(error);
       }
       reject(error);
     }
@@ -98,6 +99,7 @@ interface LaunchNextItemParams<T> {
   resolve: (value: BatchResult<T>[]) => void;
   reject: (reason: unknown) => void;
   launchNext: () => void;
+  signal?: AbortSignal;
 }
 
 const launchNextItem = <T>(params: LaunchNextItemParams<T>): void => {
@@ -109,6 +111,7 @@ const launchNextItem = <T>(params: LaunchNextItemParams<T>): void => {
     isCancelled,
     reject,
     launchNext,
+    signal,
   } = params;
   const currentIndex = state.index;
   const item = items[currentIndex];
@@ -116,7 +119,7 @@ const launchNextItem = <T>(params: LaunchNextItemParams<T>): void => {
   state.active += 1;
 
   item
-    .run(abortController ? { signal: abortController.signal } : undefined)
+    .run(signal ? { signal } : undefined)
     .then((value) => {
       recordSuccess({
         state,
@@ -146,6 +149,47 @@ const launchNextItem = <T>(params: LaunchNextItemParams<T>): void => {
     });
 };
 
+const createAbortError = (): Error => {
+  const error = new Error("Batch operation was aborted.");
+  error.name = "AbortError";
+  return error;
+};
+
+const readAbortReason = (signal: AbortSignal): unknown =>
+  signal.reason ?? createAbortError();
+
+const combineAbortSignals = (
+  first: AbortSignal | undefined,
+  second: AbortSignal | undefined,
+): AbortSignal | undefined => {
+  if (!first) {
+    return second;
+  }
+  if (!second) {
+    return first;
+  }
+
+  const controller = new AbortController();
+  const abortFrom = (signal: AbortSignal): void => {
+    if (!controller.signal.aborted) {
+      controller.abort(readAbortReason(signal));
+    }
+  };
+
+  if (first.aborted) {
+    abortFrom(first);
+    return controller.signal;
+  }
+  if (second.aborted) {
+    abortFrom(second);
+    return controller.signal;
+  }
+
+  first.addEventListener("abort", () => abortFrom(first), { once: true });
+  second.addEventListener("abort", () => abortFrom(second), { once: true });
+  return controller.signal;
+};
+
 /**
  * Returns an empty results array when called with no items.
  */
@@ -166,11 +210,23 @@ const runBatch = <T>(
   const abortController = options.stopOnError
     ? new AbortController()
     : undefined;
+  const signal = combineAbortSignals(options.signal, abortController?.signal);
 
-  const isCancelled = (): boolean =>
-    abortController?.signal.aborted ?? state.stopped;
+  const isCancelled = (): boolean => state.stopped || signal?.aborted === true;
+
+  if (signal?.aborted) {
+    return Promise.reject(readAbortReason(signal));
+  }
 
   return new Promise((resolve, reject) => {
+    if (signal) {
+      const onAbort = (): void => {
+        state.stopped = true;
+        reject(readAbortReason(signal));
+      };
+      signal.addEventListener("abort", onAbort, { once: true });
+    }
+
     const launchNext = (): void => {
       if (isCancelled()) {
         return;
@@ -191,6 +247,7 @@ const runBatch = <T>(
           resolve,
           reject,
           launchNext,
+          signal,
         });
       }
     };

--- a/src/attio/errors.ts
+++ b/src/attio/errors.ts
@@ -188,7 +188,13 @@ const attioErrorInfoSchema = z
   })
   .passthrough();
 
+const attioErrorShapeSchema = attioErrorInfoSchema.extend({
+  name: z.string(),
+  message: z.string(),
+});
+
 type AttioErrorInfo = z.infer<typeof attioErrorInfoSchema>;
+type AttioErrorShape = z.infer<typeof attioErrorShapeSchema>;
 
 const RETRYABLE_ATTIO_STATUS_CODES = [408, 429, 500, 502, 503, 504];
 
@@ -206,12 +212,17 @@ const getAttioErrorStatus = (error: unknown): number | undefined => {
   return info?.response?.status ?? info?.status ?? info?.status_code;
 };
 
+const parseAttioErrorShape = (error: unknown): AttioErrorShape | undefined => {
+  const parsed = attioErrorShapeSchema.safeParse(error);
+  return parsed.success ? parsed.data : undefined;
+};
+
 const isAttioError = (error: unknown): error is AttioError => {
   if (error instanceof AttioError) {
     return true;
   }
 
-  const info = parseAttioErrorInfo(error);
+  const info = parseAttioErrorShape(error);
   if (!info) {
     return false;
   }

--- a/src/attio/lists.ts
+++ b/src/attio/lists.ts
@@ -212,14 +212,14 @@ export function queryListEntries(
 // Implementation signature
 export function queryListEntries<T extends AttioRecordLike>(
   input: ListQueryInput<T>,
-): Promise<T[]> | AsyncIterable<T> {
+): Promise<T[] | AttioRecordLike[]> | AsyncIterable<T | AttioRecordLike> {
   const query = createRecordQueryRuntime(input);
 
   const fetchEntries = async (
     offset?: number,
     limit?: number,
     signal?: AbortSignal,
-  ): Promise<T[]> => {
+  ): Promise<T[] | AttioRecordLike[]> => {
     const result = await postV2ListsByListEntriesQuery({
       client: query.client,
       path: { list: input.list },

--- a/src/attio/metadata.ts
+++ b/src/attio/metadata.ts
@@ -121,6 +121,22 @@ interface NormalizedAllowedValue {
   archived: boolean;
 }
 
+type AttributeRequestOptions = Omit<
+  Options<GetV2ByTargetByIdentifierAttributesByAttributeData>,
+  "client" | "path"
+>;
+
+const toAttributeRequestOptions = (
+  options: ListAllowedValuesInput["options"],
+): AttributeRequestOptions | undefined => {
+  if (!options) {
+    return;
+  }
+
+  const { query: _query, ...requestOptions } = options;
+  return requestOptions;
+};
+
 interface AttributeMetadataPath extends AttributePathWithAttribute {}
 
 type AttributeMetadataFetchParams<TData extends AttributeMetadataData> =
@@ -313,6 +329,7 @@ const resolveAllowedValueType = async (
     target: input.target,
     identifier: input.identifier,
     attribute: input.attribute,
+    options: toAttributeRequestOptions(input.options),
   });
   if (attribute.type === "select" || attribute.type === "status") {
     return attribute.type;

--- a/src/attio/operations.ts
+++ b/src/attio/operations.ts
@@ -27,20 +27,33 @@ interface RecordQueryRuntime<T extends AttioRecordLike> {
   schema: ZodType<T>;
 }
 
-interface RecordQueryRuntimeInput<T extends AttioRecordLike>
+interface RecordQueryRuntimeInput<T extends AttioRecordLike = AttioRecordLike>
   extends AttioClientInput {
   filter?: AttioFilter;
   itemSchema?: ZodType<T>;
 }
 
-const createRecordQueryRuntime = <T extends AttioRecordLike>(
+function createRecordQueryRuntime<T extends AttioRecordLike>(
+  input: RecordQueryRuntimeInput<T> & { itemSchema: ZodType<T> },
+): RecordQueryRuntime<T>;
+function createRecordQueryRuntime(
+  input: RecordQueryRuntimeInput,
+): RecordQueryRuntime<AttioRecordLike>;
+function createRecordQueryRuntime<T extends AttioRecordLike>(
   input: RecordQueryRuntimeInput<T>,
-): RecordQueryRuntime<T> => ({
-  client: resolveAttioClient(input),
-  filter:
-    input.filter === undefined ? undefined : parseAttioFilter(input.filter),
-  schema: (input.itemSchema ?? rawRecordSchema) as ZodType<T>,
-});
+): RecordQueryRuntime<T> | RecordQueryRuntime<AttioRecordLike> {
+  const runtime = {
+    client: resolveAttioClient(input),
+    filter:
+      input.filter === undefined ? undefined : parseAttioFilter(input.filter),
+  };
+
+  if (input.itemSchema) {
+    return { ...runtime, schema: input.itemSchema };
+  }
+
+  return { ...runtime, schema: rawRecordSchema };
+}
 
 /**
  * Resolve client, execute API call, and unwrap a single data response.

--- a/src/attio/records.ts
+++ b/src/attio/records.ts
@@ -15,8 +15,12 @@ import {
   postV2ObjectsByObjectRecordsQuery,
   putV2ObjectsByObjectRecords,
 } from "../generated";
-import { runBatch } from "./batch";
-import { type AttioClientInput, resolveAttioClient } from "./client";
+import { type BatchItem, runBatch } from "./batch";
+import {
+  type AttioClient,
+  type AttioClientInput,
+  resolveAttioClient,
+} from "./client";
 import { AttioResponseError } from "./errors";
 import { type AttioFilter, filters, parseAttioFilter } from "./filters";
 import { type BrandedId, createBrandedIdSchema } from "./ids";
@@ -27,7 +31,12 @@ import {
   unwrapAndNormalizeRecords,
 } from "./operations";
 import { resolveOffsetItems, type SharedPaginationInput } from "./pagination";
-import { type AttioRecordLike, extractRecordId } from "./record-utils";
+import {
+  type AttioRecordLike,
+  extractRecordId,
+  normalizeRecords,
+} from "./record-utils";
+import { unwrapItems, validateItemsArray } from "./response";
 import { rawRecordSchema } from "./schemas";
 
 /**
@@ -226,6 +235,66 @@ const orderRecordsByInputIds = <T extends AttioRecordLike>(
   return ordered;
 };
 
+const unwrapGetManyRecords = (result: unknown): AttioRecordLike[] =>
+  normalizeRecords(unwrapItems<Record<string, unknown>>(result));
+
+const validateGetManyRecords = <T extends AttioRecordLike>(
+  records: AttioRecordLike[],
+  itemSchema?: ZodType<T>,
+): T[] | AttioRecordLike[] => {
+  if (itemSchema) {
+    return validateItemsArray(records, itemSchema);
+  }
+
+  return validateItemsArray(records, rawRecordSchema);
+};
+
+const createGetManyBatchItems = <T extends AttioRecordLike>(
+  input: RecordGetManyInput<T>,
+  client: AttioClient,
+  chunks: RecordId[][],
+): BatchItem<AttioRecordLike[]>[] =>
+  chunks.map((recordIds) => ({
+    label: recordIds.join(","),
+    run: async ({ signal }: { signal?: AbortSignal } = {}) => {
+      const result = await postV2ObjectsByObjectRecordsQuery({
+        client,
+        path: { object: input.object },
+        body: {
+          filter: parseAttioFilter(filters.in("record_id", [...recordIds])),
+          limit: recordIds.length,
+          offset: 0,
+        },
+        ...input.options,
+        signal,
+      });
+      return unwrapGetManyRecords(result);
+    },
+  }));
+
+const findMissingRecordIds = (
+  records: AttioRecordLike[],
+  recordIds: readonly RecordId[],
+): RecordId[] => {
+  const foundIds = new Set<string>(
+    records.flatMap((record) => {
+      const recordId = extractRecordId(record);
+      return recordId ? [recordId] : [];
+    }),
+  );
+  return recordIds.filter((recordId) => !foundIds.has(recordId));
+};
+
+const assertAllRecordsFound = (
+  records: AttioRecordLike[],
+  recordIds: readonly RecordId[],
+): void => {
+  const missing = findMissingRecordIds(records, recordIds);
+  if (missing.length > 0) {
+    throw missingRecordsError(missing);
+  }
+};
+
 // Overload: With itemSchema - T is inferred from schema
 function createRecord<T extends AttioRecordLike>(
   input: RecordCreateInput<T> & { itemSchema: ZodType<T> },
@@ -341,14 +410,14 @@ function queryRecords(
 // Implementation signature
 function queryRecords<T extends AttioRecordLike>(
   input: RecordQueryInput<T>,
-): Promise<T[]> | AsyncIterable<T> {
+): Promise<T[] | AttioRecordLike[]> | AsyncIterable<T | AttioRecordLike> {
   const query = createRecordQueryRuntime(input);
 
   const fetchRecords = async (
     offset?: number,
     limit?: number,
     signal?: AbortSignal,
-  ): Promise<T[]> => {
+  ): Promise<T[] | AttioRecordLike[]> => {
     const result = await postV2ObjectsByObjectRecordsQuery({
       client: query.client,
       path: { object: input.object },
@@ -371,35 +440,18 @@ function getManyRecords(input: RecordGetManyInput): Promise<AttioRecordLike[]>;
 // Implementation
 async function getManyRecords<T extends AttioRecordLike>(
   input: RecordGetManyInput<T>,
-): Promise<T[]> {
+): Promise<T[] | AttioRecordLike[]> {
   if (input.recordIds.length === 0) {
     return [];
   }
 
   const client = resolveAttioClient(input);
-  const schema = input.itemSchema ?? rawRecordSchema;
   const chunkSize = clampPositiveInteger(
     input.chunkSize,
     DEFAULT_GET_MANY_CHUNK_SIZE,
   );
   const chunks = chunkRecordIds(input.recordIds, chunkSize);
-  const batchItems = chunks.map((recordIds) => ({
-    label: recordIds.join(","),
-    run: async ({ signal }: { signal?: AbortSignal } = {}) => {
-      const result = await postV2ObjectsByObjectRecordsQuery({
-        client,
-        path: { object: input.object },
-        body: {
-          filter: parseAttioFilter(filters.in("record_id", [...recordIds])),
-          limit: recordIds.length,
-          offset: 0,
-        },
-        ...input.options,
-        signal: signal ?? input.signal,
-      });
-      return unwrapAndNormalizeRecords(result, schema) as T[];
-    },
-  }));
+  const batchItems = createGetManyBatchItems(input, client, chunks);
 
   const results = await runBatch(batchItems, {
     concurrency: clampPositiveInteger(
@@ -407,30 +459,25 @@ async function getManyRecords<T extends AttioRecordLike>(
       DEFAULT_GET_MANY_CONCURRENCY,
     ),
     stopOnError: true,
+    signal: input.signal,
   });
 
   const records = results.flatMap((result) => result.value ?? []);
   const notFound = input.notFound ?? "omit";
   if (input.preserveOrder ?? true) {
-    return orderRecordsByInputIds(records, input.recordIds, notFound);
+    const orderedRecords = orderRecordsByInputIds(
+      records,
+      input.recordIds,
+      notFound,
+    );
+    return validateGetManyRecords(orderedRecords, input.itemSchema);
   }
 
   if (notFound === "throw") {
-    const foundIds = new Set<string>(
-      records.flatMap((record) => {
-        const recordId = extractRecordId(record);
-        return recordId ? [recordId] : [];
-      }),
-    );
-    const missing = input.recordIds.filter(
-      (recordId) => !foundIds.has(recordId),
-    );
-    if (missing.length > 0) {
-      throw missingRecordsError(missing);
-    }
+    assertAllRecordsFound(records, input.recordIds);
   }
 
-  return records;
+  return validateGetManyRecords(records, input.itemSchema);
 }
 
 export type {

--- a/test/attio/batch.spec.ts
+++ b/test/attio/batch.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import type { BatchItem } from "../../src/attio/batch";
 import { runBatch } from "../../src/attio/batch";
@@ -95,6 +95,66 @@ describe("runBatch", () => {
     await runBatch(items, { stopOnError: false });
 
     expect(receivedSignal).toBeUndefined();
+  });
+
+  it("passes an external signal to items when provided", async () => {
+    const controller = new AbortController();
+    let receivedSignal: AbortSignal | undefined;
+
+    const items: BatchItem<string>[] = [
+      {
+        run: async (params) => {
+          receivedSignal = params?.signal;
+          return "ok";
+        },
+      },
+    ];
+
+    await runBatch(items, { signal: controller.signal });
+
+    expect(receivedSignal).toBe(controller.signal);
+  });
+
+  it("rejects without launching items when the external signal is already aborted", async () => {
+    const controller = new AbortController();
+    const reason = new Error("cancelled before start");
+    controller.abort(reason);
+    const run = vi.fn(async () => "never");
+
+    await expect(
+      runBatch([{ run }], { signal: controller.signal }),
+    ).rejects.toBe(reason);
+
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it("stops launching queued items after the external signal aborts", async () => {
+    const controller = new AbortController();
+    const reason = new Error("cancelled during batch");
+    const started: string[] = [];
+    const items: BatchItem<string>[] = [
+      {
+        label: "first",
+        run: async () => {
+          started.push("first");
+          controller.abort(reason);
+          return "first";
+        },
+      },
+      {
+        label: "second",
+        run: async () => {
+          started.push("second");
+          return "second";
+        },
+      },
+    ];
+
+    await expect(
+      runBatch(items, { concurrency: 1, signal: controller.signal }),
+    ).rejects.toBe(reason);
+
+    expect(started).toEqual(["first"]);
   });
 
   it("handles items without labels", async () => {

--- a/test/attio/errors.spec.ts
+++ b/test/attio/errors.spec.ts
@@ -329,7 +329,7 @@ describe("AttioError cause", () => {
 });
 
 describe("stable error helpers", () => {
-  it("narrows Attio errors without requiring instanceof", () => {
+  it("narrows Attio errors only when required Error fields are present", () => {
     expect(isAttioError(new AttioError("boom"))).toBe(true);
     expect(
       isAttioError({
@@ -338,6 +338,7 @@ describe("stable error helpers", () => {
         status: 404,
       }),
     ).toBe(true);
+    expect(isAttioError({ name: "AttioApiError", status: 404 })).toBe(false);
     expect(isAttioError({ name: "Error", message: "plain" })).toBe(false);
   });
 

--- a/test/attio/metadata.spec.ts
+++ b/test/attio/metadata.spec.ts
@@ -467,6 +467,35 @@ describe("metadata", () => {
       ]);
     });
 
+    it("forwards request options while resolving the allowed value type", async () => {
+      const getMock = vi.mocked(getV2ByTargetByIdentifierAttributesByAttribute);
+      const statusesMock = vi.mocked(
+        getV2ByTargetByIdentifierAttributesByAttributeStatuses,
+      );
+      const headers = { "X-Request-Id": "req-123" };
+      getMock.mockResolvedValue({
+        data: createMockAttribute({ api_slug: "stage", type: "status" }),
+      });
+      statusesMock.mockResolvedValue({
+        data: [createMockStatus({ title: "Active" })],
+      });
+
+      await listAllowedValues({
+        ...buildInput("stage"),
+        options: { headers, query: { show_archived: true } },
+      });
+
+      const attributeCall = getMock.mock.calls[0]?.[0];
+      expect(attributeCall).toEqual(expect.objectContaining({ headers }));
+      expect(attributeCall).not.toHaveProperty("query");
+      expect(statusesMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          headers,
+          query: { show_archived: true },
+        }),
+      );
+    });
+
     it("rejects attributes without allowed values", async () => {
       const getMock = vi.mocked(getV2ByTargetByIdentifierAttributesByAttribute);
       getMock.mockResolvedValue({

--- a/test/attio/records.spec.ts
+++ b/test/attio/records.spec.ts
@@ -502,6 +502,51 @@ describe("records", () => {
       });
     });
 
+    it("does not launch more chunks after the caller signal aborts", async () => {
+      const controller = new AbortController();
+      const reason = new Error("cancelled getManyRecords");
+      queryRecordsRequest.mockImplementationOnce(async () => {
+        controller.abort(reason);
+        return {
+          data: {
+            data: [{ id: { record_id: "rec-1" }, values: {} }],
+          },
+        };
+      });
+
+      await expect(
+        getManyRecords({
+          object: "companies",
+          recordIds: ["rec-1", "rec-2"],
+          chunkSize: 1,
+          concurrency: 1,
+          signal: controller.signal,
+        }),
+      ).rejects.toBe(reason);
+
+      expect(queryRecordsRequest).toHaveBeenCalledTimes(1);
+    });
+
+    it("preserves order before applying an itemSchema that strips IDs", async () => {
+      const itemSchema = z.object({ name: z.string() });
+      queryRecordsRequest.mockResolvedValueOnce({
+        data: {
+          data: [
+            { id: { record_id: "rec-2" }, values: {}, name: "Beta" },
+            { id: { record_id: "rec-1" }, values: {}, name: "Acme" },
+          ],
+        },
+      });
+
+      const result = await getManyRecords({
+        object: "companies",
+        recordIds: ["rec-1", "rec-2"],
+        itemSchema,
+      });
+
+      expect(result).toEqual([{ name: "Acme" }, { name: "Beta" }]);
+    });
+
     it("throws when requested records are missing and notFound is throw", async () => {
       queryRecordsRequest.mockResolvedValue({
         data: {


### PR DESCRIPTION
Propagate caller abort signals through batch execution.

Preserve raw record IDs until getManyRecords ordering completes.

Tighten error-shape parsing and forward metadata request options.

Model: GPT-5 Codex

Reasoning-Effort: medium

Thread: 019e22a4-d278-7552-9500-ea79b848378d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Batch operations now support cancellation via external abort signals, enabling callers to stop in-progress batch execution.

* **Improvements**
  * Enhanced error validation for stricter type checking.
  * Improved record retrieval with better ordering and validation consistency.
  * Refined option forwarding in list and record query operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hbmartin/attio-ts-sdk/pull/150)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add external AbortSignal support to `runBatch` and fix `isAttioError` message validation
> - Adds `options.signal` to `runBatch` in [batch.ts](https://github.com/hbmartin/attio-ts-sdk/pull/150/files#diff-dd99219b1b258fad4093d1382cfb3a1e325c4b08eb186d5ce855a8925733feb5), combining it with the internal `stopOnError` controller via a new `combineAbortSignals` utility. Rejects immediately if the signal is already aborted and stops launching queued items on abort.
> - Threads the combined signal through to each batch item's `run` callback so items can respond to both external cancellation and `stopOnError` aborts.
> - Fixes `isAttioError` in [errors.ts](https://github.com/hbmartin/attio-ts-sdk/pull/150/files#diff-04f0a9359a4656765ea144a17d039c333e7c22700e807dbbcdcdb4ea13301b12) to require both `name` and `message` fields; previously objects missing `message` could be incorrectly identified as Attio errors.
> - Forwards request options (e.g. headers) but not query parameters when resolving attribute types in [metadata.ts](https://github.com/hbmartin/attio-ts-sdk/pull/150/files#diff-0e76ae01f12f86552ad2c060b38343063fd2b3fc0845720b2a03ec6697781ea1).
> - Refactors `getManyRecords` in [records.ts](https://github.com/hbmartin/attio-ts-sdk/pull/150/files#diff-d42989800fb297664ffead7c17cfb0c61cae4a9361c9c7ca8e4c00a81dcaecc3) to pass the caller's `AbortSignal` to `runBatch` and validates records after order preservation, fixing item schemas that strip IDs from breaking ordering.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0a25105.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->