### PR TITLE
fix: use branded note parent ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -1004,14 +1004,20 @@ const { data: entry } = await postV2ListsByListEntries({
 ### Notes and Tasks
 
 ```typescript
-import { createAttioSdk } from 'attio-ts-sdk';
+import {
+  createAttioSdk,
+  createNoteParentObjectId,
+  createNoteParentRecordId,
+} from 'attio-ts-sdk';
 
 const sdk = createAttioSdk({ apiKey: process.env.ATTIO_API_KEY });
+const companyObject = createNoteParentObjectId('companies');
+const companyRecordId = createNoteParentRecordId('abc-123');
 
 // Create a note on a record.
 const note = await sdk.notes.create({
-  parentObject: 'companies',
-  parentRecordId: 'abc-123',
+  parentObject: companyObject,
+  parentRecordId: companyRecordId,
   title: 'Meeting Notes',
   format: 'markdown',
   content: 'Discussed Q4 roadmap...',
@@ -1038,16 +1044,21 @@ await sdk.tasks.update({
 
 ### Listing and Viewing Person Notes
 
-Use `sdk.notes.list` with `parentObject: 'people'` and the person's record ID to list notes attached to a specific person. Set `paginate: true` to collect every page, or `paginate: 'stream'` to iterate notes lazily.
+Use `sdk.notes.list` with a branded `parentObject` for `people` and the person's branded record ID to list notes attached to a specific person. Set `paginate: true` to collect every page, or `paginate: 'stream'` to iterate notes lazily.
 
 ```typescript
-import { createAttioSdk } from 'attio-ts-sdk';
+import {
+  createAttioSdk,
+  createNoteParentObjectId,
+  createNoteParentRecordId,
+} from 'attio-ts-sdk';
 
 const sdk = createAttioSdk({ apiKey: process.env.ATTIO_API_KEY });
-const personRecordId = 'person-record-id';
+const personObject = createNoteParentObjectId('people');
+const personRecordId = createNoteParentRecordId('person-record-id');
 
 const personNotes = await sdk.notes.list({
-  parentObject: 'people',
+  parentObject: personObject,
   parentRecordId: personRecordId,
   paginate: true,
   limit: 50,

--- a/src/attio/notes.ts
+++ b/src/attio/notes.ts
@@ -63,8 +63,8 @@ interface NoteDeleteInput extends AttioClientInput {
 }
 
 interface NoteListBaseInput extends AttioClientInput {
-  parentObject?: NoteListQuery["parent_object"];
-  parentRecordId?: NoteListQuery["parent_record_id"];
+  parentObject?: NoteParentObjectId;
+  parentRecordId?: NoteParentRecordId;
   limit?: NoteListQuery["limit"];
   offset?: NoteListQuery["offset"];
   signal?: AbortSignal;

--- a/test/attio/notes.spec.ts
+++ b/test/attio/notes.spec.ts
@@ -121,10 +121,14 @@ describe("notes", () => {
 
     it("passes parent filters and pagination query parameters", async () => {
       getNotesRequest.mockResolvedValue({ data: { data: [] } });
+      const parentObject = createNoteParentObjectId("people");
+      const parentRecordId = createNoteParentRecordId(
+        "c3d4e5f6-a7b8-4c9d-ae0f-1a2b3c4d5e6f",
+      );
 
       await listNotes({
-        parentObject: "people",
-        parentRecordId: "c3d4e5f6-a7b8-4c9d-ae0f-1a2b3c4d5e6f",
+        parentObject,
+        parentRecordId,
         limit: 25,
         offset: 50,
         options: { headers: { "X-Custom": "value" } },
@@ -161,13 +165,17 @@ describe("notes", () => {
           note_id: "33333333-3333-4333-8333-333333333333",
         },
       });
+      const parentObject = createNoteParentObjectId("people");
+      const parentRecordId = createNoteParentRecordId(
+        "c3d4e5f6-a7b8-4c9d-ae0f-1a2b3c4d5e6f",
+      );
       getNotesRequest
         .mockResolvedValueOnce({ data: { data: [note1, note2] } })
         .mockResolvedValueOnce({ data: { data: [note3] } });
 
       const result = await listNotes({
-        parentObject: "people",
-        parentRecordId: "c3d4e5f6-a7b8-4c9d-ae0f-1a2b3c4d5e6f",
+        parentObject,
+        parentRecordId,
         paginate: true,
         limit: 2,
       });
@@ -213,10 +221,12 @@ describe("notes", () => {
     it("creates note with all parameters", async () => {
       const newNote = createMockNote({ title: "New note" });
       postNotesRequest.mockResolvedValue({ data: newNote });
+      const parentObject = createNoteParentObjectId("companies");
+      const parentRecordId = createNoteParentRecordId("rec-123");
 
       const result = await createNote({
-        parentObject: "companies",
-        parentRecordId: "rec-123",
+        parentObject,
+        parentRecordId,
         title: "New note",
         content: "Note content",
       });
@@ -238,10 +248,12 @@ describe("notes", () => {
     it("creates note with minimal parameters", async () => {
       const note = createMockNote();
       postNotesRequest.mockResolvedValue({ data: note });
+      const parentObject = createNoteParentObjectId("people");
+      const parentRecordId = createNoteParentRecordId("rec-456");
 
       await createNote({
-        parentObject: "people",
-        parentRecordId: "rec-456",
+        parentObject,
+        parentRecordId,
       });
 
       expect(postNotesRequest).toHaveBeenCalledWith({
@@ -260,10 +272,12 @@ describe("notes", () => {
     it("passes additional options", async () => {
       const note = createMockNote();
       postNotesRequest.mockResolvedValue({ data: note });
+      const parentObject = createNoteParentObjectId("companies");
+      const parentRecordId = createNoteParentRecordId("rec-123");
 
       await createNote({
-        parentObject: "companies",
-        parentRecordId: "rec-123",
+        parentObject,
+        parentRecordId,
         options: { headers: { "X-Custom": "value" } },
       });
 

--- a/test/attio/sdk.spec.ts
+++ b/test/attio/sdk.spec.ts
@@ -72,6 +72,12 @@ vi.mock("../../src/attio/schema", () => mocks.schema);
 
 describe("createAttioSdk", () => {
   it("binds client into convenience methods", async () => {
+    const { createNoteParentObjectId, createNoteParentRecordId } =
+      await vi.importActual<typeof import("../../src/attio/notes")>(
+        "../../src/attio/notes",
+      );
+    const noteParentObject = createNoteParentObjectId("people");
+    const noteParentRecordId = createNoteParentRecordId("rec_1");
     const mockFetch: typeof fetch = () =>
       Promise.resolve(
         new Response(JSON.stringify({ data: {} }), {
@@ -123,11 +129,14 @@ describe("createAttioSdk", () => {
     });
     await sdk.lists.removeEntry({ list: "list_1", entryId: "entry_1" });
 
-    await sdk.notes.list({ parentObject: "people", parentRecordId: "rec_1" });
+    await sdk.notes.list({
+      parentObject: noteParentObject,
+      parentRecordId: noteParentRecordId,
+    });
     await sdk.notes.get({ noteId: "note_1" });
     await sdk.notes.create({
-      parentObject: "people",
-      parentRecordId: "rec_1",
+      parentObject: noteParentObject,
+      parentRecordId: noteParentRecordId,
       title: "Intro call",
       format: "plaintext",
       content: "Discussed next steps.",
@@ -260,8 +269,8 @@ describe("createAttioSdk", () => {
 
     expect(mocks.notes.listNotes).toHaveBeenCalledWith({
       client,
-      parentObject: "people",
-      parentRecordId: "rec_1",
+      parentObject: noteParentObject,
+      parentRecordId: noteParentRecordId,
     });
     expect(mocks.notes.getNote).toHaveBeenCalledWith({
       client,
@@ -269,8 +278,8 @@ describe("createAttioSdk", () => {
     });
     expect(mocks.notes.createNote).toHaveBeenCalledWith({
       client,
-      parentObject: "people",
-      parentRecordId: "rec_1",
+      parentObject: noteParentObject,
+      parentRecordId: noteParentRecordId,
       title: "Intro call",
       format: "plaintext",
       content: "Discussed next steps.",


### PR DESCRIPTION
Use branded note parent IDs for note list filters.

Refresh README examples and tests to use exported ID factories.

Model: GPT-5 Codex (reasoning: medium)

Thread: 019e22c2-a5df-7110-a496-061f7581005c

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Use branded types for note `parentObject` and `parentRecordId` parameters
> Replaces raw string types with `NoteParentObjectId` and `NoteParentRecordId` branded types in the `NoteListBaseInput` interface, and updates the SDK, tests, and README examples to construct these values via `createNoteParentObjectId` and `createNoteParentRecordId` helpers.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized acc7e40.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Note API documentation examples to demonstrate usage of branded helper factories for parent identifiers.

* **Refactor**
  * Improved internal type safety for Note API by adopting branded types for parent object and record identifiers.

* **Tests**
  * Updated test suite to use branded ID factories consistently across all note API operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hbmartin/attio-ts-sdk/pull/152)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->