### PR TITLE
fix: clean up batch abort listeners

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,9 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  '@types/node': ^24
-
 importers:
 
   .:

--- a/src/attio/batch.ts
+++ b/src/attio/batch.ts
@@ -158,36 +158,155 @@ const createAbortError = (): Error => {
 const readAbortReason = (signal: AbortSignal): unknown =>
   signal.reason ?? createAbortError();
 
+const doNothing = (): void => undefined;
+
+interface CombinedAbortSignals {
+  signal?: AbortSignal;
+  cleanup?: () => void;
+}
+
 const combineAbortSignals = (
   first: AbortSignal | undefined,
   second: AbortSignal | undefined,
-): AbortSignal | undefined => {
+): CombinedAbortSignals => {
   if (!first) {
-    return second;
+    return { signal: second };
   }
   if (!second) {
-    return first;
+    return { signal: first };
   }
 
   const controller = new AbortController();
+  let cleanupListeners = doNothing;
   const abortFrom = (signal: AbortSignal): void => {
+    cleanupListeners();
     if (!controller.signal.aborted) {
       controller.abort(readAbortReason(signal));
     }
   };
+  const abortFromFirst = (): void => abortFrom(first);
+  const abortFromSecond = (): void => abortFrom(second);
+  let hasCleanedUp = false;
+  cleanupListeners = (): void => {
+    if (hasCleanedUp) {
+      return;
+    }
+    hasCleanedUp = true;
+    first.removeEventListener("abort", abortFromFirst);
+    second.removeEventListener("abort", abortFromSecond);
+  };
 
   if (first.aborted) {
     abortFrom(first);
-    return controller.signal;
+    return { signal: controller.signal };
   }
   if (second.aborted) {
     abortFrom(second);
-    return controller.signal;
+    return { signal: controller.signal };
   }
 
-  first.addEventListener("abort", () => abortFrom(first), { once: true });
-  second.addEventListener("abort", () => abortFrom(second), { once: true });
-  return controller.signal;
+  first.addEventListener("abort", abortFromFirst, { once: true });
+  second.addEventListener("abort", abortFromSecond, { once: true });
+  return { signal: controller.signal, cleanup: cleanupListeners };
+};
+
+interface BatchSettlementParams<T> {
+  resolve: (value: BatchResult<T>[]) => void;
+  reject: (reason?: unknown) => void;
+  cleanup: () => void;
+}
+
+interface BatchSettlement<T> {
+  resolve: (value: BatchResult<T>[]) => void;
+  reject: (reason: unknown) => void;
+}
+
+const createBatchSettlement = <T>(
+  params: BatchSettlementParams<T>,
+): BatchSettlement<T> => {
+  const { resolve, reject, cleanup } = params;
+  let settled = false;
+  return {
+    resolve: (value) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
+      resolve(value);
+    },
+    reject: (reason) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
+      reject(reason);
+    },
+  };
+};
+
+interface RegisterBatchAbortListenerParams<T> {
+  signal: AbortSignal;
+  state: BatchState<T>;
+  reject: (reason: unknown) => void;
+}
+
+const registerBatchAbortListener = <T>(
+  params: RegisterBatchAbortListenerParams<T>,
+): (() => void) => {
+  const { signal, state, reject } = params;
+  const onAbort = (): void => {
+    state.stopped = true;
+    reject(readAbortReason(signal));
+  };
+  signal.addEventListener("abort", onAbort, { once: true });
+  return () => {
+    signal.removeEventListener("abort", onAbort);
+  };
+};
+
+type CreateBatchLauncherParams<T> = Omit<LaunchNextItemParams<T>, "launchNext">;
+
+const createBatchLauncher = <T>(
+  params: CreateBatchLauncherParams<T>,
+): (() => void) => {
+  const {
+    items,
+    state,
+    concurrency,
+    abortController,
+    options,
+    isCancelled,
+    resolve,
+    reject,
+    signal,
+  } = params;
+  const launchNext = (): void => {
+    if (isCancelled()) {
+      return;
+    }
+    if (state.index >= items.length && state.active === 0) {
+      resolve(state.results);
+      return;
+    }
+
+    while (state.active < concurrency && state.index < items.length) {
+      launchNextItem({
+        items,
+        state,
+        concurrency,
+        abortController,
+        options,
+        isCancelled,
+        resolve,
+        reject,
+        launchNext,
+        signal,
+      });
+    }
+  };
+  return launchNext;
 };
 
 /**
@@ -210,48 +329,50 @@ const runBatch = <T>(
   const abortController = options.stopOnError
     ? new AbortController()
     : undefined;
-  const signal = combineAbortSignals(options.signal, abortController?.signal);
+  const combinedSignal = combineAbortSignals(
+    options.signal,
+    abortController?.signal,
+  );
+  const { signal, cleanup: cleanupCombinedSignal } = combinedSignal;
 
   const isCancelled = (): boolean => state.stopped || signal?.aborted === true;
 
   if (signal?.aborted) {
+    cleanupCombinedSignal?.();
     return Promise.reject(readAbortReason(signal));
   }
 
   return new Promise((resolve, reject) => {
+    let cleanupAbortListener = doNothing;
+    const cleanup = (): void => {
+      cleanupAbortListener();
+      cleanupCombinedSignal?.();
+    };
+    const batchSettlement = createBatchSettlement<T>({
+      resolve,
+      reject,
+      cleanup,
+    });
+
     if (signal) {
-      const onAbort = (): void => {
-        state.stopped = true;
-        reject(readAbortReason(signal));
-      };
-      signal.addEventListener("abort", onAbort, { once: true });
+      cleanupAbortListener = registerBatchAbortListener({
+        signal,
+        state,
+        reject: batchSettlement.reject,
+      });
     }
 
-    const launchNext = (): void => {
-      if (isCancelled()) {
-        return;
-      }
-      if (state.index >= items.length && state.active === 0) {
-        resolve(state.results);
-        return;
-      }
-
-      while (state.active < concurrency && state.index < items.length) {
-        launchNextItem({
-          items,
-          state,
-          concurrency,
-          abortController,
-          options,
-          isCancelled,
-          resolve,
-          reject,
-          launchNext,
-          signal,
-        });
-      }
-    };
-
+    const launchNext = createBatchLauncher({
+      items,
+      state,
+      concurrency,
+      abortController,
+      options,
+      isCancelled,
+      resolve: batchSettlement.resolve,
+      reject: batchSettlement.reject,
+      signal,
+    });
     launchNext();
   });
 };

--- a/src/attio/metadata.ts
+++ b/src/attio/metadata.ts
@@ -121,10 +121,11 @@ interface NormalizedAllowedValue {
   archived: boolean;
 }
 
-type AttributeRequestOptions = Omit<
-  Options<GetV2ByTargetByIdentifierAttributesByAttributeData>,
-  "client" | "path"
->;
+interface AttributeRequestOptions
+  extends Omit<
+    Options<GetV2ByTargetByIdentifierAttributesByAttributeData>,
+    "client" | "path"
+  > {}
 
 const toAttributeRequestOptions = (
   options: ListAllowedValuesInput["options"],

--- a/test/attio/batch.spec.ts
+++ b/test/attio/batch.spec.ts
@@ -115,6 +115,88 @@ describe("runBatch", () => {
     expect(receivedSignal).toBe(controller.signal);
   });
 
+  it("removes the external abort listener after completion", async () => {
+    const controller = new AbortController();
+    const addSpy = vi.spyOn(controller.signal, "addEventListener");
+    const removeSpy = vi.spyOn(controller.signal, "removeEventListener");
+
+    const results = await runBatch([{ label: "done", run: async () => "ok" }], {
+      signal: controller.signal,
+    });
+
+    const abortListener = addSpy.mock.calls.find(
+      ([event]) => event === "abort",
+    )?.[1];
+    if (!abortListener) {
+      throw new Error("Expected runBatch to register an abort listener.");
+    }
+
+    expect(results).toEqual([
+      { status: "fulfilled", value: "ok", label: "done" },
+    ]);
+    expect(removeSpy).toHaveBeenCalledWith("abort", abortListener);
+  });
+
+  it("removes combined source listeners after completion", async () => {
+    const controller = new AbortController();
+    const addSpy = vi.spyOn(controller.signal, "addEventListener");
+    const removeSpy = vi.spyOn(controller.signal, "removeEventListener");
+    let receivedSignal: AbortSignal | undefined;
+
+    await runBatch(
+      [
+        {
+          run: async (params) => {
+            receivedSignal = params?.signal;
+            return "ok";
+          },
+        },
+      ],
+      { signal: controller.signal, stopOnError: true },
+    );
+
+    const abortListener = addSpy.mock.calls.find(
+      ([event]) => event === "abort",
+    )?.[1];
+    if (!abortListener) {
+      throw new Error("Expected combined signal to watch the external signal.");
+    }
+
+    expect(receivedSignal).toBeDefined();
+    expect(receivedSignal).not.toBe(controller.signal);
+    expect(removeSpy).toHaveBeenCalledWith("abort", abortListener);
+  });
+
+  it("removes combined source listeners when the external signal aborts", async () => {
+    const controller = new AbortController();
+    const addSpy = vi.spyOn(controller.signal, "addEventListener");
+    const removeSpy = vi.spyOn(controller.signal, "removeEventListener");
+    const reason = new Error("cancelled");
+
+    await expect(
+      runBatch(
+        [
+          {
+            run: async () => {
+              controller.abort(reason);
+              return "ignored";
+            },
+          },
+        ],
+        { signal: controller.signal, stopOnError: true },
+      ),
+    ).rejects.toBe(reason);
+
+    const abortListener = addSpy.mock.calls.find(
+      ([event]) => event === "abort",
+    )?.[1];
+    if (!abortListener) {
+      throw new Error("Expected combined signal to watch the external signal.");
+    }
+
+    expect(removeSpy).toHaveBeenCalledWith("abort", abortListener);
+  });
+
   it("rejects without launching items when the external signal is already aborted", async () => {
     const controller = new AbortController();
     const reason = new Error("cancelled before start");


### PR DESCRIPTION
Remove abort listeners from batch cancellation paths when work settles. Clean up combined signal source listeners and align AttributeRequestOptions with the interface-first convention.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal batch execution handling with enhanced resource cleanup mechanisms.

* **Tests**
  * Added test coverage for abort signal cleanup in batch operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hbmartin/attio-ts-sdk/pull/153)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix abort listener cleanup in `runBatch` to prevent listener leaks
> - `runBatch` now unregisters external abort listeners and combined-signal source listeners on completion or abortion, preventing listener leaks.
> - `combineAbortSignals` in [batch.ts](https://github.com/hbmartin/attio-ts-sdk/pull/153/files#diff-dd99219b1b258fad4093d1382cfb3a1e325c4b08eb186d5ce855a8925733feb5) now returns a `cleanup` function alongside the combined signal; listeners are removed both on abort and when the caller invokes cleanup.
> - Adds `createBatchSettlement` to ensure resolve/reject runs only once and always invokes cleanup, and `registerBatchAbortListener` to centralize one-time abort listener setup.
> - New tests in [batch.spec.ts](https://github.com/hbmartin/attio-ts-sdk/pull/153/files#diff-444df8176c0533272395969355a1e462e72c1a74f2d7af875cf0c78b5236bbf2) assert that listeners are removed after successful completion, after `stopOnError` completion, and when the external signal aborts.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c18caca.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->