### PR TITLE
fix: close batch abort registration race

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
-          version: 9
+          version: 11.1.1
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:

--- a/.github/workflows/openapi-sync.yml
+++ b/.github/workflows/openapi-sync.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
-          version: 9
+          version: 11.1.1
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -35,7 +35,7 @@ jobs:
 
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
-          version: 9
+          version: 11.1.1
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
   "resolutions": {
     "@types/node": "^22"
   },
+  "packageManager": "pnpm@11.1.1",
   "jscpd": {
     "threshold": 0,
     "reporters": [

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+packages:
+  - .
+
+allowBuilds:
+  esbuild: true

--- a/src/attio/batch.ts
+++ b/src/attio/batch.ts
@@ -256,17 +256,33 @@ const registerBatchAbortListener = <T>(
   params: RegisterBatchAbortListenerParams<T>,
 ): (() => void) => {
   const { signal, state, reject } = params;
+  let hasAborted = false;
+  let hasCleanedUp = false;
+  const cleanup = (): void => {
+    if (hasCleanedUp) {
+      return;
+    }
+    hasCleanedUp = true;
+    signal.removeEventListener("abort", onAbort);
+  };
   const onAbort = (): void => {
+    if (hasAborted) {
+      return;
+    }
+    hasAborted = true;
+    cleanup();
     state.stopped = true;
     reject(readAbortReason(signal));
   };
   signal.addEventListener("abort", onAbort, { once: true });
-  return () => {
-    signal.removeEventListener("abort", onAbort);
-  };
+  if (signal.aborted) {
+    onAbort();
+  }
+  return cleanup;
 };
 
-type CreateBatchLauncherParams<T> = Omit<LaunchNextItemParams<T>, "launchNext">;
+interface CreateBatchLauncherParams<T>
+  extends Omit<LaunchNextItemParams<T>, "launchNext"> {}
 
 const createBatchLauncher = <T>(
   params: CreateBatchLauncherParams<T>,

--- a/test/attio/batch.spec.ts
+++ b/test/attio/batch.spec.ts
@@ -210,6 +210,33 @@ describe("runBatch", () => {
     expect(run).not.toHaveBeenCalled();
   });
 
+  it("rejects when the external signal becomes aborted while registering the abort listener", async () => {
+    const controller = new AbortController();
+    const reason = new Error("cancelled during listener registration");
+    const addSpy = vi.spyOn(controller.signal, "addEventListener");
+    const removeSpy = vi.spyOn(controller.signal, "removeEventListener");
+    const abortedSpy = vi.spyOn(controller.signal, "aborted", "get");
+    const reasonSpy = vi.spyOn(controller.signal, "reason", "get");
+    const run = vi.fn(async (): Promise<string> => "never");
+
+    abortedSpy.mockReturnValueOnce(false).mockReturnValue(true);
+    reasonSpy.mockReturnValue(reason);
+
+    await expect(
+      runBatch([{ run }], { signal: controller.signal }),
+    ).rejects.toBe(reason);
+
+    const abortListener = addSpy.mock.calls.find(
+      ([event]) => event === "abort",
+    )?.[1];
+    if (!abortListener) {
+      throw new Error("Expected runBatch to register an abort listener.");
+    }
+
+    expect(run).not.toHaveBeenCalled();
+    expect(removeSpy).toHaveBeenCalledWith("abort", abortListener);
+  });
+
   it("stops launching queued items after the external signal aborts", async () => {
     const controller = new AbortController();
     const reason = new Error("cancelled during batch");

--- a/test/attio/config.spec.ts
+++ b/test/attio/config.spec.ts
@@ -10,6 +10,43 @@ import {
   resolveThrowOnError,
 } from "../../src/attio/config";
 
+const restoreGlobalProperty = (
+  key: string,
+  descriptor: PropertyDescriptor | undefined,
+): void => {
+  if (descriptor) {
+    Object.defineProperty(globalThis, key, descriptor);
+    return;
+  }
+
+  Reflect.deleteProperty(globalThis, key);
+};
+
+const withGlobalProperties = <T>(
+  properties: Record<string, unknown>,
+  action: () => T,
+): T => {
+  const descriptors = Object.keys(properties).map((key) => ({
+    descriptor: Object.getOwnPropertyDescriptor(globalThis, key),
+    key,
+  }));
+
+  try {
+    for (const [key, value] of Object.entries(properties)) {
+      Object.defineProperty(globalThis, key, {
+        configurable: true,
+        value,
+        writable: true,
+      });
+    }
+    return action();
+  } finally {
+    for (const { key, descriptor } of descriptors) {
+      restoreGlobalProperty(key, descriptor);
+    }
+  }
+};
+
 describe("getEnvValue", () => {
   const originalEnv = process.env;
 
@@ -29,6 +66,34 @@ describe("getEnvValue", () => {
   it("returns undefined when variable not set", () => {
     delete process.env.NONEXISTENT_VAR;
     expect(getEnvValue("NONEXISTENT_VAR")).toBeUndefined();
+  });
+
+  it("uses Deno.env before process.env when Deno is available", () => {
+    const result = withGlobalProperties(
+      {
+        Deno: {
+          env: {
+            get: (key: string): string | undefined =>
+              key === "TEST_VAR" ? "deno-value" : undefined,
+          },
+        },
+      },
+      () => getEnvValue("TEST_VAR"),
+    );
+
+    expect(result).toBe("deno-value");
+  });
+
+  it("returns undefined when no supported environment global exists", () => {
+    const result = withGlobalProperties(
+      {
+        Deno: undefined,
+        process: undefined,
+      },
+      () => getEnvValue("TEST_VAR"),
+    );
+
+    expect(result).toBeUndefined();
   });
 });
 

--- a/test/attio/filters.spec.ts
+++ b/test/attio/filters.spec.ts
@@ -234,6 +234,12 @@ describe("filters", () => {
         },
       });
     });
+
+    it("rejects empty paths", () => {
+      expect(() => filters.path([], { value: "rec-123" })).toThrow(
+        "path segments must be non-empty",
+      );
+    });
   });
 
   describe("complex combinations", () => {
@@ -326,6 +332,23 @@ describe("filters", () => {
           ["people", "email_addresses"],
         ],
         constraints: { email_domain: { $contains: "example.com" } },
+      });
+    });
+
+    it("uses value as the default parent record contains field", () => {
+      expect(
+        filters.parentRecordContains({
+          list: "hiring-pipeline",
+          object: "people",
+          attribute: "name",
+          value: "Ada",
+        }),
+      ).toEqual({
+        path: [
+          ["hiring-pipeline", "parent_record"],
+          ["people", "name"],
+        ],
+        constraints: { value: { $contains: "Ada" } },
       });
     });
 

--- a/test/attio/logging.spec.ts
+++ b/test/attio/logging.spec.ts
@@ -1,10 +1,48 @@
 import { describe, expect, it, vi } from "vitest";
+import { AttioResponseError } from "../../src/attio/errors";
 import type { AttioLogger } from "../../src/attio/hooks";
 import {
   createCorrelationIdManager,
   createStructuredLoggerHooks,
   redactLogContext,
 } from "../../src/attio/logging";
+
+const restoreGlobalProperty = (
+  key: string,
+  descriptor: PropertyDescriptor | undefined,
+): void => {
+  if (descriptor) {
+    Object.defineProperty(globalThis, key, descriptor);
+    return;
+  }
+
+  Reflect.deleteProperty(globalThis, key);
+};
+
+const withGlobalProperties = <T>(
+  properties: Record<string, unknown>,
+  action: () => T,
+): T => {
+  const descriptors = Object.keys(properties).map((key) => ({
+    descriptor: Object.getOwnPropertyDescriptor(globalThis, key),
+    key,
+  }));
+
+  try {
+    for (const [key, value] of Object.entries(properties)) {
+      Object.defineProperty(globalThis, key, {
+        configurable: true,
+        value,
+        writable: true,
+      });
+    }
+    return action();
+  } finally {
+    for (const { key, descriptor } of descriptors) {
+      restoreGlobalProperty(key, descriptor);
+    }
+  }
+};
 
 describe("logging", () => {
   describe("redactLogContext", () => {
@@ -37,6 +75,46 @@ describe("logging", () => {
         url: "https://api.attio.com/v2/records?token=%5BREDACTED%5D&status=active",
       });
     });
+
+    it("redacts sensitive params from relative URLs", () => {
+      const redacted = redactLogContext({
+        url: "/v2/records?api_key=abc123&status=active#section",
+      });
+
+      expect(redacted).toEqual({
+        url: "/v2/records?api_key=%5BREDACTED%5D&status=active#section",
+      });
+    });
+
+    it("leaves invalid URL strings unchanged", () => {
+      const redacted = redactLogContext({
+        url: "http://[::1",
+      });
+
+      expect(redacted).toEqual({
+        url: "http://[::1",
+      });
+    });
+
+    it("can disable redaction", () => {
+      const context = {
+        authorization: "Bearer visible",
+        url: "https://api.attio.com/v2/records?token=visible",
+      };
+
+      expect(
+        redactLogContext(context, { redaction: { enabled: false } }),
+      ).toEqual(context);
+    });
+
+    it("ignores empty sensitive key patterns", () => {
+      const redacted = redactLogContext(
+        { authorization: "Bearer visible" },
+        { redaction: { sensitiveKeyPatterns: [""] } },
+      );
+
+      expect(redacted).toEqual({ authorization: "Bearer visible" });
+    });
   });
 
   describe("createCorrelationIdManager", () => {
@@ -66,9 +144,55 @@ describe("logging", () => {
       expect(enrichedRequest).toBe(request);
       expect(manager.readFromRequest(enrichedRequest)).toBeUndefined();
     });
+
+    it("returns undefined when reading without a request", () => {
+      const manager = createCorrelationIdManager();
+
+      expect(manager.readFromRequest()).toBeUndefined();
+    });
+
+    it("reads existing headers and does not clone already correlated requests", () => {
+      const manager = createCorrelationIdManager({
+        correlationId: { headerName: " X-Correlation-ID " },
+      });
+      const request = new Request("https://api.attio.com/v2/objects", {
+        headers: { "x-correlation-id": "existing-corr-id" },
+      });
+
+      expect(manager.readFromRequest(request)).toBe("existing-corr-id");
+      expect(manager.enrichRequest(request)).toBe(request);
+    });
+
+    it("falls back to timestamp correlation IDs when randomUUID is unavailable", () => {
+      const nowSpy = vi.spyOn(Date, "now").mockReturnValue(36);
+      const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0.5);
+
+      try {
+        const correlationId = withGlobalProperties({ crypto: {} }, () => {
+          const manager = createCorrelationIdManager();
+          const request = manager.enrichRequest(
+            new Request("https://api.attio.com/v2/objects"),
+          );
+          return request.headers.get("x-attio-correlation-id");
+        });
+
+        expect(correlationId).toBe("10-i");
+      } finally {
+        nowSpy.mockRestore();
+        randomSpy.mockRestore();
+      }
+    });
   });
 
   describe("createStructuredLoggerHooks", () => {
+    it("returns no hooks when no logger is provided", () => {
+      const hooks = createStructuredLoggerHooks({
+        correlationIds: createCorrelationIdManager(),
+      });
+
+      expect(hooks).toEqual({});
+    });
+
     it("logs redacted structured context with correlation ID", () => {
       const debug = vi.fn();
       const logger: AttioLogger = { debug };
@@ -109,6 +233,110 @@ describe("logging", () => {
           headers: expect.objectContaining({
             authorization: "[REDACTED]",
           }),
+        }),
+      );
+    });
+
+    it("logs response context with correlation ID read from the request", () => {
+      const debug = vi.fn();
+      const logger: AttioLogger = { debug };
+      const correlationIds = createCorrelationIdManager({
+        correlationId: {
+          create: () => "response-corr-id",
+        },
+      });
+      const hooks = createStructuredLoggerHooks({
+        logger,
+        correlationIds,
+      });
+      const request = correlationIds.enrichRequest(
+        new Request("https://api.attio.com/v2/objects", { method: "POST" }),
+      );
+      const response = new Response(null, { status: 201 });
+
+      hooks.onResponse?.({
+        request,
+        response,
+        options: { url: "/v2/objects" },
+      });
+
+      expect(debug).toHaveBeenCalledWith(
+        "attio.response",
+        expect.objectContaining({
+          correlationId: "response-corr-id",
+          method: "POST",
+          ok: true,
+          status: 201,
+          url: "https://api.attio.com/v2/objects",
+        }),
+      );
+    });
+
+    it("does not add correlation context when correlation IDs are disabled", () => {
+      const debug = vi.fn();
+      const logger: AttioLogger = { debug };
+      const correlationIds = createCorrelationIdManager({
+        correlationId: { enabled: false },
+      });
+      const hooks = createStructuredLoggerHooks({
+        logger,
+        correlationIds,
+      });
+
+      hooks.onResponse?.({
+        request: new Request("https://api.attio.com/v2/objects"),
+        response: new Response(null, { status: 200 }),
+        options: { url: "/v2/objects" },
+      });
+
+      expect(debug).toHaveBeenCalledWith(
+        "attio.response",
+        expect.not.objectContaining({
+          correlationId: expect.any(String),
+        }),
+      );
+    });
+
+    it("logs error context with request and response details", () => {
+      const errorLog = vi.fn();
+      const logger: AttioLogger = { error: errorLog };
+      const correlationIds = createCorrelationIdManager({
+        correlationId: {
+          contextKey: "traceId",
+          create: () => "error-trace-id",
+        },
+      });
+      const hooks = createStructuredLoggerHooks({
+        logger,
+        correlationIds,
+      });
+      const request = correlationIds.enrichRequest(
+        new Request("https://api.attio.com/v2/records?token=hidden"),
+      );
+      const response = new Response(null, { status: 429 });
+      const error = new AttioResponseError("Rate limited", {
+        code: "RATE_LIMITED",
+        status: 429,
+      });
+      error.requestId = "req-123";
+
+      hooks.onError?.({
+        error,
+        request,
+        response,
+        options: { url: "/v2/records" },
+      });
+
+      expect(errorLog).toHaveBeenCalledWith(
+        "attio.error",
+        expect.objectContaining({
+          code: "RATE_LIMITED",
+          message: "Rate limited",
+          requestId: "req-123",
+          responseStatus: 429,
+          status: 429,
+          traceId: "error-trace-id",
+          url: "https://api.attio.com/v2/records?token=%5BREDACTED%5D",
         }),
       );
     });

--- a/test/attio/objects.spec.ts
+++ b/test/attio/objects.spec.ts
@@ -28,16 +28,41 @@ describe("objects", () => {
   let getObject: typeof import("../../src/attio/objects").getObject;
   let createObject: typeof import("../../src/attio/objects").createObject;
   let updateObject: typeof import("../../src/attio/objects").updateObject;
+  let createObjectSlug: typeof import("../../src/attio/objects").createObjectSlug;
+  let createObjectApiSlug: typeof import("../../src/attio/objects").createObjectApiSlug;
+  let createObjectNoun: typeof import("../../src/attio/objects").createObjectNoun;
 
   beforeAll(async () => {
-    ({ listObjects, getObject, createObject, updateObject } = await import(
-      "../../src/attio/objects"
-    ));
+    ({
+      listObjects,
+      getObject,
+      createObject,
+      updateObject,
+      createObjectSlug,
+      createObjectApiSlug,
+      createObjectNoun,
+    } = await import("../../src/attio/objects"));
   });
 
   beforeEach(() => {
     vi.clearAllMocks();
     resolveAttioClient.mockReturnValue({});
+  });
+
+  describe("ID factories", () => {
+    it("creates branded object identifiers", () => {
+      expect(createObjectSlug("people")).toBe("people");
+      expect(createObjectApiSlug("custom_deals")).toBe("custom_deals");
+      expect(createObjectNoun("Deal")).toBe("Deal");
+    });
+
+    it("rejects empty object identifiers", () => {
+      expect(() => createObjectSlug("")).toThrow("ObjectSlug cannot be empty");
+      expect(() => createObjectApiSlug("")).toThrow(
+        "Object API slug cannot be empty",
+      );
+      expect(() => createObjectNoun("")).toThrow("ObjectNoun cannot be empty");
+    });
   });
 
   it("lists objects", async () => {
@@ -143,6 +168,37 @@ describe("objects", () => {
     const calledBody = updateObjectRequest.mock.calls[0][0].body;
     expect(calledBody.data).not.toHaveProperty("api_slug");
     expect(calledBody.data).not.toHaveProperty("plural_noun");
+  });
+
+  it("updates an object with every optional field when provided", async () => {
+    updateObjectRequest.mockResolvedValue({
+      data: {
+        id: { workspace_id: "ws_1", object_id: "obj_1" },
+        api_slug: "opportunities",
+        singular_noun: "Opportunity",
+        plural_noun: "Opportunities",
+        created_at: "2024-01-01T00:00:00Z",
+      },
+    });
+
+    await updateObject({
+      object: "deals",
+      apiSlug: "opportunities",
+      singularNoun: "Opportunity",
+      pluralNoun: "Opportunities",
+    });
+
+    expect(updateObjectRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: {
+          data: {
+            api_slug: "opportunities",
+            singular_noun: "Opportunity",
+            plural_noun: "Opportunities",
+          },
+        },
+      }),
+    );
   });
 
   it("propagates errors from updateObject request", async () => {

--- a/test/attio/records.spec.ts
+++ b/test/attio/records.spec.ts
@@ -564,6 +564,75 @@ describe("records", () => {
         code: "RECORDS_NOT_FOUND",
       });
     });
+
+    it("returns records in fetched order when preserveOrder is false", async () => {
+      queryRecordsRequest.mockResolvedValue({
+        data: {
+          data: [
+            { id: { record_id: "rec-2" }, values: {} },
+            { id: { record_id: "rec-1" }, values: {} },
+          ],
+        },
+      });
+
+      const result = await getManyRecords({
+        object: "companies",
+        recordIds: ["rec-1", "rec-2"],
+        preserveOrder: false,
+      });
+
+      expect(result.map((record) => record.id)).toEqual([
+        { record_id: "rec-2" },
+        { record_id: "rec-1" },
+      ]);
+    });
+
+    it("throws for unordered results when notFound is throw and a record is missing", async () => {
+      queryRecordsRequest.mockResolvedValue({
+        data: {
+          data: [{ id: { record_id: "rec-1" }, values: {} }],
+        },
+      });
+
+      await expect(
+        getManyRecords({
+          object: "companies",
+          recordIds: ["rec-1", "rec-missing"],
+          preserveOrder: false,
+          notFound: "throw",
+        }),
+      ).rejects.toMatchObject({
+        code: "RECORDS_NOT_FOUND",
+        data: { recordIds: ["rec-missing"] },
+      });
+    });
+
+    it("uses fallback chunking and concurrency for invalid numeric options", async () => {
+      queryRecordsRequest.mockResolvedValue({
+        data: {
+          data: [
+            { id: { record_id: "rec-1" }, values: {} },
+            { id: { record_id: "rec-2" }, values: {} },
+          ],
+        },
+      });
+
+      await getManyRecords({
+        object: "companies",
+        recordIds: ["rec-1", "rec-2"],
+        chunkSize: Number.NaN,
+        concurrency: 0,
+      });
+
+      expect(queryRecordsRequest).toHaveBeenCalledTimes(1);
+      expect(queryRecordsRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: expect.objectContaining({
+            limit: 2,
+          }),
+        }),
+      );
+    });
   });
 
   describe("queryRecords", () => {

--- a/test/attio/sdk.spec.ts
+++ b/test/attio/sdk.spec.ts
@@ -51,9 +51,11 @@ const mocks = vi.hoisted(() => ({
   },
   metadata: {
     listAttributes: vi.fn().mockResolvedValue([]),
+    findAttribute: vi.fn().mockResolvedValue(undefined),
     getAttribute: vi.fn().mockResolvedValue({}),
     getAttributeOptions: vi.fn().mockResolvedValue([]),
     getAttributeStatuses: vi.fn().mockResolvedValue([]),
+    listAllowedValues: vi.fn().mockResolvedValue([]),
   },
   schema: {
     createSchema: vi.fn().mockResolvedValue({ attributes: [] }),
@@ -170,6 +172,11 @@ describe("createAttioSdk", () => {
       target: "objects",
       identifier: "companies",
     });
+    await sdk.metadata.findAttribute({
+      target: "objects",
+      identifier: "companies",
+      slug: "name",
+    });
     await sdk.metadata.getAttribute({
       target: "objects",
       identifier: "companies",
@@ -181,6 +188,11 @@ describe("createAttioSdk", () => {
       attribute: "stage",
     });
     await sdk.metadata.getAttributeStatuses({
+      target: "objects",
+      identifier: "companies",
+      attribute: "stage",
+    });
+    await sdk.metadata.listAllowedValues({
       target: "objects",
       identifier: "companies",
       attribute: "stage",
@@ -337,6 +349,12 @@ describe("createAttioSdk", () => {
       target: "objects",
       identifier: "companies",
     });
+    expect(mocks.metadata.findAttribute).toHaveBeenCalledWith({
+      client,
+      target: "objects",
+      identifier: "companies",
+      slug: "name",
+    });
     expect(mocks.metadata.getAttribute).toHaveBeenCalledWith({
       client,
       target: "objects",
@@ -350,6 +368,12 @@ describe("createAttioSdk", () => {
       attribute: "stage",
     });
     expect(mocks.metadata.getAttributeStatuses).toHaveBeenCalledWith({
+      client,
+      target: "objects",
+      identifier: "companies",
+      attribute: "stage",
+    });
+    expect(mocks.metadata.listAllowedValues).toHaveBeenCalledWith({
       client,
       target: "objects",
       identifier: "companies",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pnpm to version 11.1.1 across CI workflows and project configuration.
  * Added pnpm workspace configuration file.

* **Tests**
  * Expanded test coverage for batch processing, environment configuration, filters, logging, object operations, record retrieval, and SDK functionality.

* **Refactor**
  * Enhanced batch abort listener handling with improved reliability and cleanup mechanisms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hbmartin/attio-ts-sdk/pull/155)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix race condition in `registerBatchAbortListener` when signal is already aborted
> - Adds `hasAborted` and `hasCleanedUp` guards in [`src/attio/batch.ts`](https://github.com/hbmartin/attio-ts-sdk/pull/155/files#diff-dd99219b1b258fad4093d1382cfb3a1e325c4b08eb186d5ce855a8925733feb5) so duplicate abort events never trigger multiple rejections.
> - Immediately invokes the abort handler if the `AbortSignal` is already aborted at registration time, closing the race window.
> - The abort listener is now registered with `once: true` and removed via a cleanup function that executes exactly once.
> - Adds a regression test in [`test/attio/batch.spec.ts`](https://github.com/hbmartin/attio-ts-sdk/pull/155/files#diff-444df8176c0533272395969355a1e462e72c1a74f2d7af875cf0c78b5236bbf2) covering the already-aborted signal scenario.
> - Also upgrades pnpm to 11.1.1 across CI workflows and adds a `pnpm-workspace.yaml`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cd38370.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->