### PR TITLE
test: Extract duplicated global override helpers, made async cleanup safe, restored the CreateBatchLauncherParams type alias, and added focused batch abort coverage.

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "publint": "^0.3.20",
     "tsdown": "^0.22.0",
     "typescript": "^6.0.3",
-    "undici-types": "^8.2.0",
+    "undici-types": ">=6.21.0",
     "vitest": "^4.1.6",
     "zod": "^4.4.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,8 +45,8 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
       undici-types:
-        specifier: ^8.2.0
-        version: 8.2.0
+        specifier: '>=6.21.0'
+        version: 6.21.0
       vitest:
         specifier: ^4.1.6
         version: 4.1.6(@types/node@22.19.19)(@vitest/coverage-istanbul@4.1.6)(vite@7.3.1(@types/node@22.19.19)(jiti@2.7.0))
@@ -1970,9 +1970,6 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
-
-  undici-types@8.2.0:
-    resolution: {integrity: sha512-uciYZ5yCmf+QJb18kJw10HjquzM7K0z992vWcI+84KeBpTfXT4hfgfGJ5DQbf/mCBPACofkrjvqgcjZfuujjFA==}
 
   unicode-emoji-modifier-base@1.0.0:
     resolution: {integrity: sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g==}
@@ -3952,8 +3949,6 @@ snapshots:
       quansync: 1.0.0
 
   undici-types@6.21.0: {}
-
-  undici-types@8.2.0: {}
 
   unicode-emoji-modifier-base@1.0.0: {}
 

--- a/src/attio/batch.ts
+++ b/src/attio/batch.ts
@@ -281,8 +281,7 @@ const registerBatchAbortListener = <T>(
   return cleanup;
 };
 
-interface CreateBatchLauncherParams<T>
-  extends Omit<LaunchNextItemParams<T>, "launchNext"> {}
+type CreateBatchLauncherParams<T> = Omit<LaunchNextItemParams<T>, "launchNext">;
 
 const createBatchLauncher = <T>(
   params: CreateBatchLauncherParams<T>,

--- a/test/attio/batch.spec.ts
+++ b/test/attio/batch.spec.ts
@@ -210,6 +210,27 @@ describe("runBatch", () => {
     expect(run).not.toHaveBeenCalled();
   });
 
+  it("uses a fallback AbortError when an aborted signal has no reason", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const reasonSpy = vi.spyOn(controller.signal, "reason", "get");
+    const run = vi.fn(async () => "never");
+
+    reasonSpy.mockReturnValue(undefined);
+
+    try {
+      await expect(
+        runBatch([{ run }], { signal: controller.signal }),
+      ).rejects.toMatchObject({
+        message: "Batch operation was aborted.",
+        name: "AbortError",
+      });
+      expect(run).not.toHaveBeenCalled();
+    } finally {
+      reasonSpy.mockRestore();
+    }
+  });
+
   it("rejects when the external signal becomes aborted while registering the abort listener", async () => {
     const controller = new AbortController();
     const reason = new Error("cancelled during listener registration");
@@ -235,6 +256,37 @@ describe("runBatch", () => {
 
     expect(run).not.toHaveBeenCalled();
     expect(removeSpy).toHaveBeenCalledWith("abort", abortListener);
+  });
+
+  it("rejects once when an abort listener is invoked after cancellation", async () => {
+    const controller = new AbortController();
+    const addSpy = vi.spyOn(controller.signal, "addEventListener");
+    const removeSpy = vi.spyOn(controller.signal, "removeEventListener");
+    const reason = new Error("cancelled once");
+
+    const batch = runBatch(
+      [
+        {
+          run: async () => {
+            await new Promise((resolve) => setTimeout(resolve, 10));
+            return "ignored";
+          },
+        },
+      ],
+      { signal: controller.signal },
+    );
+    const abortListener = addSpy.mock.calls.find(
+      ([event]) => event === "abort",
+    )?.[1];
+    if (typeof abortListener !== "function") {
+      throw new Error("Expected runBatch to register an abort listener.");
+    }
+
+    controller.abort(reason);
+    abortListener(new Event("abort"));
+
+    await expect(batch).rejects.toBe(reason);
+    expect(removeSpy).toHaveBeenCalledTimes(1);
   });
 
   it("stops launching queued items after the external signal aborts", async () => {

--- a/test/attio/config.spec.ts
+++ b/test/attio/config.spec.ts
@@ -9,43 +9,7 @@ import {
   resolveResponseStyle,
   resolveThrowOnError,
 } from "../../src/attio/config";
-
-const restoreGlobalProperty = (
-  key: string,
-  descriptor: PropertyDescriptor | undefined,
-): void => {
-  if (descriptor) {
-    Object.defineProperty(globalThis, key, descriptor);
-    return;
-  }
-
-  Reflect.deleteProperty(globalThis, key);
-};
-
-const withGlobalProperties = <T>(
-  properties: Record<string, unknown>,
-  action: () => T,
-): T => {
-  const descriptors = Object.keys(properties).map((key) => ({
-    descriptor: Object.getOwnPropertyDescriptor(globalThis, key),
-    key,
-  }));
-
-  try {
-    for (const [key, value] of Object.entries(properties)) {
-      Object.defineProperty(globalThis, key, {
-        configurable: true,
-        value,
-        writable: true,
-      });
-    }
-    return action();
-  } finally {
-    for (const { key, descriptor } of descriptors) {
-      restoreGlobalProperty(key, descriptor);
-    }
-  }
-};
+import { withGlobalProperties } from "../test-utils";
 
 describe("getEnvValue", () => {
   const originalEnv = process.env;

--- a/test/attio/logging.spec.ts
+++ b/test/attio/logging.spec.ts
@@ -6,43 +6,7 @@ import {
   createStructuredLoggerHooks,
   redactLogContext,
 } from "../../src/attio/logging";
-
-const restoreGlobalProperty = (
-  key: string,
-  descriptor: PropertyDescriptor | undefined,
-): void => {
-  if (descriptor) {
-    Object.defineProperty(globalThis, key, descriptor);
-    return;
-  }
-
-  Reflect.deleteProperty(globalThis, key);
-};
-
-const withGlobalProperties = <T>(
-  properties: Record<string, unknown>,
-  action: () => T,
-): T => {
-  const descriptors = Object.keys(properties).map((key) => ({
-    descriptor: Object.getOwnPropertyDescriptor(globalThis, key),
-    key,
-  }));
-
-  try {
-    for (const [key, value] of Object.entries(properties)) {
-      Object.defineProperty(globalThis, key, {
-        configurable: true,
-        value,
-        writable: true,
-      });
-    }
-    return action();
-  } finally {
-    for (const { key, descriptor } of descriptors) {
-      restoreGlobalProperty(key, descriptor);
-    }
-  }
-};
+import { withGlobalProperties } from "../test-utils";
 
 describe("logging", () => {
   describe("redactLogContext", () => {

--- a/test/test-utils.spec.ts
+++ b/test/test-utils.spec.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+
+import { restoreGlobalProperty, withGlobalProperties } from "./test-utils";
+
+describe("test utils", () => {
+  it("restores global properties after a sync action", () => {
+    const key = "__attio_sync_test_global__";
+    const originalDescriptor = Object.getOwnPropertyDescriptor(globalThis, key);
+
+    try {
+      const result = withGlobalProperties({ [key]: "temporary" }, () =>
+        Reflect.get(globalThis, key),
+      );
+
+      expect(result).toBe("temporary");
+      if (originalDescriptor) {
+        expect(Object.getOwnPropertyDescriptor(globalThis, key)).toEqual(
+          originalDescriptor,
+        );
+      } else {
+        expect(Reflect.has(globalThis, key)).toBe(false);
+      }
+    } finally {
+      restoreGlobalProperty(key, originalDescriptor);
+    }
+  });
+
+  it("restores global properties after an async action settles", async () => {
+    const key = "__attio_async_test_global__";
+    const originalDescriptor = Object.getOwnPropertyDescriptor(globalThis, key);
+
+    try {
+      const result = await withGlobalProperties(
+        { [key]: "temporary" },
+        async () => {
+          const beforeAwait = Reflect.get(globalThis, key);
+          await Promise.resolve();
+          return {
+            afterAwait: Reflect.get(globalThis, key),
+            beforeAwait,
+          };
+        },
+      );
+
+      expect(result).toEqual({
+        afterAwait: "temporary",
+        beforeAwait: "temporary",
+      });
+      if (originalDescriptor) {
+        expect(Object.getOwnPropertyDescriptor(globalThis, key)).toEqual(
+          originalDescriptor,
+        );
+      } else {
+        expect(Reflect.has(globalThis, key)).toBe(false);
+      }
+    } finally {
+      restoreGlobalProperty(key, originalDescriptor);
+    }
+  });
+});

--- a/test/test-utils.ts
+++ b/test/test-utils.ts
@@ -1,0 +1,73 @@
+interface GlobalPropertySnapshot {
+  key: string;
+  descriptor: PropertyDescriptor | undefined;
+}
+
+const snapshotGlobalProperties = (
+  properties: Record<string, unknown>,
+): GlobalPropertySnapshot[] =>
+  Object.keys(properties).map((key) => ({
+    descriptor: Object.getOwnPropertyDescriptor(globalThis, key),
+    key,
+  }));
+
+const restoreGlobalProperty = (
+  key: string,
+  descriptor: PropertyDescriptor | undefined,
+): void => {
+  if (descriptor) {
+    Object.defineProperty(globalThis, key, descriptor);
+    return;
+  }
+
+  Reflect.deleteProperty(globalThis, key);
+};
+
+const restoreGlobalProperties = (snapshots: GlobalPropertySnapshot[]): void => {
+  for (const { key, descriptor } of snapshots) {
+    restoreGlobalProperty(key, descriptor);
+  }
+};
+
+const defineGlobalProperties = (properties: Record<string, unknown>): void => {
+  for (const [key, value] of Object.entries(properties)) {
+    Object.defineProperty(globalThis, key, {
+      configurable: true,
+      value,
+      writable: true,
+    });
+  }
+};
+
+function withGlobalProperties<T>(
+  properties: Record<string, unknown>,
+  action: () => Promise<T>,
+): Promise<T>;
+function withGlobalProperties<T>(
+  properties: Record<string, unknown>,
+  action: () => T,
+): T;
+function withGlobalProperties<T>(
+  properties: Record<string, unknown>,
+  action: () => T | Promise<T>,
+): T | Promise<T> {
+  const snapshots = snapshotGlobalProperties(properties);
+  defineGlobalProperties(properties);
+
+  try {
+    const result = action();
+    if (result instanceof Promise) {
+      return result.finally(() => {
+        restoreGlobalProperties(snapshots);
+      });
+    }
+
+    restoreGlobalProperties(snapshots);
+    return result;
+  } catch (error) {
+    restoreGlobalProperties(snapshots);
+    throw error;
+  }
+}
+
+export { restoreGlobalProperty, withGlobalProperties };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development dependency version constraint.

* **Tests**
  * Expanded test coverage for batch operation cancellation handling.
  * Introduced shared test utilities for global property mocking across test suites.
  * Added comprehensive test suite for test utility functions.

* **Refactor**
  * Consolidated test helper functions into a shared utilities module.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hbmartin/attio-ts-sdk/pull/156)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Extract shared test helpers and add batch abort coverage
> - Adds `withGlobalProperties` and `restoreGlobalProperty` helpers to [test/test-utils.ts](https://github.com/hbmartin/attio-ts-sdk/pull/156/files#diff-2cf01d03222a34294066e6c173aea4831d26113df10f6a8969dc29a3f97cb467), centralizing logic previously duplicated in [test/attio/config.spec.ts](https://github.com/hbmartin/attio-ts-sdk/pull/156/files#diff-dd5474f8dd855e23785b65890eefb389a6bbcd5c9f9803f9378d86807bcb3609) and [test/attio/logging.spec.ts](https://github.com/hbmartin/attio-ts-sdk/pull/156/files#diff-18a0eb5f0159ff823caefaa7a31a8848459509b12cc28ebb95e99051b11f19fc).
> - The helpers snapshot global properties before a test, define temporary values, run a sync or async action, then restore originals even on error.
> - Adds two focused tests in [test/attio/batch.spec.ts](https://github.com/hbmartin/attio-ts-sdk/pull/156/files#diff-444df8176c0533272395969355a1e462e72c1a74f2d7af875cf0c78b5236bbf2) covering `runBatch` abort behavior: fallback `AbortError` when signal has no reason, and single-rejection guarantee when abort fires after cancellation.
> - Replaces empty `CreateBatchLauncherParams` interface with a direct type alias in [src/attio/batch.ts](https://github.com/hbmartin/attio-ts-sdk/pull/156/files#diff-dd99219b1b258fad4093d1382cfb3a1e325c4b08eb186d5ce855a8925733feb5).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a12faac.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->