### PR TITLE
feat: add safer retries and schema write builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,6 +397,30 @@ const values = {
 await sdk.records.create({ object: 'companies', values });
 ```
 
+For metadata-aware writes, create a schema and use `buildValues`. It accepts
+attribute titles or `api_slug`s, rejects non-writable attributes, validates
+select/status values against metadata, and serializes native JavaScript values:
+
+```typescript
+const schema = await createSchema({
+  client,
+  target: 'objects',
+  identifier: 'companies',
+});
+
+const values = await schema.buildValues({
+  Name: 'Acme Corp',
+  Website: 'acme.com',
+  Stage: 'Customer',
+  owner_company: {
+    targetObject: 'companies',
+    targetRecordId: 'rec_123',
+  },
+});
+
+await sdk.records.create({ object: 'companies', values });
+```
+
 ### Record Value Accessors
 
 `getValue` and `getFirstValue` extract attribute values from a record object. Pass an optional Zod schema to get typed, validated results.

--- a/src/attio/client.ts
+++ b/src/attio/client.ts
@@ -270,7 +270,11 @@ type RequestWithMethodOptions<
 > = Omit<RequestOptions<TData, TResponseStyle, ThrowOnError>, "method"> &
   Pick<Required<RequestOptions<TData, TResponseStyle, ThrowOnError>>, "method">;
 
-const wrapClient = (base: Client, retry?: Partial<RetryConfig>): Client => {
+const wrapClient = (
+  base: Client,
+  retry?: Partial<RetryConfig>,
+  headers?: AttioClientConfig["headers"],
+): Client => {
   const requestWithRetry: Client["request"] = <
     TData = unknown,
     TError = unknown,
@@ -285,6 +289,10 @@ const wrapClient = (base: Client, retry?: Partial<RetryConfig>): Client => {
       {
         ...retry,
         ...retryOverride,
+      },
+      {
+        method: rest.method,
+        headers: mergeHeaders(headers, rest.headers),
       },
     );
   };
@@ -376,7 +384,7 @@ const createAttioClientWithAuthToken = ({
 
   applyInterceptors(base, hooks, correlationIds);
 
-  const wrapped = wrapClient(base, retry);
+  const wrapped = wrapClient(base, retry, mergedHeaders);
   const metadataCacheKey = buildMetadataCacheKey({
     config,
     authToken,

--- a/src/attio/errors.ts
+++ b/src/attio/errors.ts
@@ -8,6 +8,7 @@ interface AttioErrorDetails {
   status?: number;
   message?: string;
   data?: unknown;
+  errors?: unknown[];
   cause?: unknown;
 }
 
@@ -26,6 +27,7 @@ class AttioError extends Error {
   response?: Response;
   request?: Request;
   retryAfterMs?: number;
+  errors?: unknown[];
   isNetworkError?: boolean;
   isApiError?: boolean;
   suggestions?: unknown;
@@ -37,6 +39,7 @@ class AttioError extends Error {
     this.code = details.code;
     this.type = details.type;
     this.data = details.data;
+    this.errors = details.errors;
   }
 }
 
@@ -154,17 +157,60 @@ const extractStatusCode = (
   return;
 };
 
+const attioErrorPayloadSchema = z
+  .object({
+    code: z.string().optional(),
+    type: z.string().optional(),
+    status: z.number().optional(),
+    status_code: z.number().optional(),
+    message: z.string().optional(),
+  })
+  .passthrough();
+
+const attioErrorEnvelopeSchema = z
+  .object({
+    error: z.unknown().optional(),
+    errors: z.array(z.unknown()).optional(),
+  })
+  .passthrough();
+
+const extractNestedErrorPayload = (error: unknown): unknown => {
+  const parsed = attioErrorEnvelopeSchema.safeParse(error);
+  if (!parsed.success) {
+    return error;
+  }
+
+  const nestedPayload = parsed.data.error ?? parsed.data.errors?.[0];
+  if (nestedPayload === undefined) {
+    return error;
+  }
+
+  const nestedResult = attioErrorPayloadSchema.safeParse(nestedPayload);
+  return nestedResult.success ? nestedResult.data : error;
+};
+
+const extractNestedErrors = (error: unknown): unknown[] | undefined => {
+  const parsed = attioErrorEnvelopeSchema.safeParse(error);
+  if (!parsed.success) {
+    return;
+  }
+  return parsed.data.errors;
+};
+
 const extractDetails = (error: unknown): AttioErrorDetails => {
-  if (!error || typeof error !== "object") {
+  const payloadSource = extractNestedErrorPayload(error);
+  const parsedPayload = attioErrorPayloadSchema.safeParse(payloadSource);
+  if (!parsedPayload.success) {
     return {};
   }
-  const payload = error as Record<string, unknown>;
+  const payload = parsedPayload.data;
   return {
-    code: typeof payload.code === "string" ? payload.code : undefined,
-    type: typeof payload.type === "string" ? payload.type : undefined,
+    code: payload.code,
+    type: payload.type,
     status: extractStatusCode(payload),
-    message: typeof payload.message === "string" ? payload.message : undefined,
-    data: payload,
+    message: payload.message,
+    data: error,
+    errors: extractNestedErrors(error),
   };
 };
 
@@ -209,7 +255,36 @@ const getAttioErrorStatus = (error: unknown): number | undefined => {
   }
 
   const info = parseAttioErrorInfo(error);
-  return info?.response?.status ?? info?.status ?? info?.status_code;
+  if (info?.response?.status ?? info?.status ?? info?.status_code) {
+    return info?.response?.status ?? info?.status ?? info?.status_code;
+  }
+
+  return extractDetails(error).status;
+};
+
+const getAttioErrorCode = (error: unknown): string | undefined => {
+  if (error instanceof AttioError) {
+    return error.code;
+  }
+
+  const info = parseAttioErrorInfo(error);
+  return info?.code ?? extractDetails(error).code;
+};
+
+const getAttioErrorType = (error: unknown): string | undefined => {
+  if (error instanceof AttioError) {
+    return error.type;
+  }
+
+  const info = parseAttioErrorInfo(error);
+  return info?.type ?? extractDetails(error).type;
+};
+
+const getAttioErrorPayload = (error: unknown): unknown => {
+  if (error instanceof AttioError) {
+    return error.data;
+  }
+  return extractNestedErrorPayload(error);
 };
 
 const parseAttioErrorShape = (error: unknown): AttioErrorShape | undefined => {
@@ -234,8 +309,48 @@ const isAttioError = (error: unknown): error is AttioError => {
   );
 };
 
+const isAttioAuthError = (error: unknown): boolean => {
+  const status = getAttioErrorStatus(error);
+  const type = getAttioErrorType(error);
+  const code = getAttioErrorCode(error);
+  return status === 401 || type === "auth_error" || code === "unauthorized";
+};
+
+const isAttioPermissionError = (error: unknown): boolean => {
+  const status = getAttioErrorStatus(error);
+  const code = getAttioErrorCode(error);
+  return (
+    status === 403 ||
+    code === "forbidden" ||
+    code === "permission_denied" ||
+    code === "system_edit_unauthorized"
+  );
+};
+
 const isAttioNotFound = (error: unknown): boolean =>
-  getAttioErrorStatus(error) === 404;
+  getAttioErrorStatus(error) === 404 ||
+  getAttioErrorCode(error) === "not_found";
+
+const isAttioRateLimitError = (error: unknown): boolean => {
+  const code = getAttioErrorCode(error);
+  return (
+    getAttioErrorStatus(error) === 429 ||
+    code === "rate_limited" ||
+    code === "rate_limit_exceeded"
+  );
+};
+
+const isAttioValidationError = (error: unknown): boolean => {
+  const status = getAttioErrorStatus(error);
+  const type = getAttioErrorType(error);
+  const code = getAttioErrorCode(error);
+  return (
+    status === 422 ||
+    type === "validation_error" ||
+    code === "validation_type" ||
+    code === "invalid_request"
+  );
+};
 
 const isRetryableAttioError = (error: unknown): boolean => {
   const info = parseAttioErrorInfo(error);
@@ -253,10 +368,8 @@ const normalizeAttioError = (
   const { response, request } = context;
   const details = extractDetails(error);
   const status = response?.status ?? details.status;
-  const message = extractMessage(
-    error,
-    response?.statusText ?? details.message,
-  );
+  const message =
+    details.message ?? extractMessage(error, response?.statusText);
   const requestId =
     getHeaderValue(response, "x-request-id") ??
     getHeaderValue(response, "x-attio-request-id");
@@ -289,9 +402,16 @@ export {
   AttioNetworkError,
   AttioResponseError,
   AttioRetryError,
+  getAttioErrorCode,
+  getAttioErrorPayload,
   getAttioErrorStatus,
+  getAttioErrorType,
+  isAttioAuthError,
   isAttioError,
   isAttioNotFound,
+  isAttioPermissionError,
+  isAttioRateLimitError,
+  isAttioValidationError,
   isRetryableAttioError,
   normalizeAttioError,
 };

--- a/src/attio/index.ts
+++ b/src/attio/index.ts
@@ -25,3 +25,4 @@ export * from "./tasks";
 export * from "./value-schemas";
 export * from "./values";
 export * from "./workspace-members";
+export * from "./write-values";

--- a/src/attio/retry.ts
+++ b/src/attio/retry.ts
@@ -2,12 +2,31 @@ import { z } from "zod";
 import type { RequestResult, ResponseStyle } from "../generated/client";
 import { AttioError, AttioRetryError } from "./errors";
 
+type RetryHttpMethod =
+  | "CONNECT"
+  | "DELETE"
+  | "GET"
+  | "HEAD"
+  | "OPTIONS"
+  | "PATCH"
+  | "POST"
+  | "PUT"
+  | "TRACE";
+
+interface RetryRequestContext {
+  method?: RetryHttpMethod;
+  headers?: unknown;
+}
+
 interface RetryConfig {
   maxRetries: number;
   initialDelayMs: number;
   maxDelayMs: number;
   retryableStatusCodes: number[];
+  retryableMethods: RetryHttpMethod[];
   respectRetryAfter: boolean;
+  retryUnsafeRequests: boolean;
+  idempotencyHeaderNames: string[];
 }
 
 const DEFAULT_RETRY_CONFIG: RetryConfig = {
@@ -15,7 +34,10 @@ const DEFAULT_RETRY_CONFIG: RetryConfig = {
   initialDelayMs: 500,
   maxDelayMs: 5000,
   retryableStatusCodes: [408, 429, 500, 502, 503, 504],
+  retryableMethods: ["GET", "HEAD", "OPTIONS"],
   respectRetryAfter: true,
+  retryUnsafeRequests: false,
+  idempotencyHeaderNames: ["Idempotency-Key", "X-Idempotency-Key"],
 };
 
 const RetryErrorSchema = z.object({
@@ -23,6 +45,21 @@ const RetryErrorSchema = z.object({
   isNetworkError: z.boolean().optional(),
   retryAfterMs: z.number().optional(),
 });
+
+const retryHttpMethodSchema = z.enum([
+  "CONNECT",
+  "DELETE",
+  "GET",
+  "HEAD",
+  "OPTIONS",
+  "PATCH",
+  "POST",
+  "PUT",
+  "TRACE",
+]);
+
+const headerTupleSchema = z.tuple([z.string(), z.unknown()]);
+const headerRecordSchema = z.record(z.string(), z.unknown());
 
 type RetryErrorInfo = z.infer<typeof RetryErrorSchema>;
 
@@ -79,9 +116,75 @@ const isRetryableError = (error: unknown, config: RetryConfig): boolean => {
 const getRetryAfterMs = (error: unknown): number | undefined =>
   extractRetryErrorInfo(error)?.retryAfterMs;
 
+const getHeaderEntries = (headers: unknown): [string, unknown][] => {
+  if (headers === undefined) {
+    return [];
+  }
+
+  if (headers instanceof Headers) {
+    const entries: [string, string][] = [];
+    headers.forEach((value, key) => {
+      entries.push([key, value]);
+    });
+    return entries;
+  }
+
+  const tupleResult = z.array(headerTupleSchema).safeParse(headers);
+  if (tupleResult.success) {
+    return tupleResult.data;
+  }
+
+  const recordResult = headerRecordSchema.safeParse(headers);
+  if (recordResult.success) {
+    return Object.entries(recordResult.data);
+  }
+
+  return [];
+};
+
+const hasIdempotencyHeader = (
+  headers: unknown,
+  headerNames: readonly string[],
+): boolean => {
+  const normalizedNames = new Set(
+    headerNames.map((headerName) => headerName.toLowerCase()),
+  );
+
+  return getHeaderEntries(headers).some(([key, value]) => {
+    if (!normalizedNames.has(key.toLowerCase())) {
+      return false;
+    }
+    return value !== undefined && value !== null && String(value).length > 0;
+  });
+};
+
+const isRetryableRequest = (
+  context: RetryRequestContext | undefined,
+  config: RetryConfig,
+): boolean => {
+  if (config.retryUnsafeRequests) {
+    return true;
+  }
+
+  if (!context?.method) {
+    return true;
+  }
+
+  const methodResult = retryHttpMethodSchema.safeParse(context.method);
+  if (
+    methodResult.success &&
+    config.retryableMethods.includes(methodResult.data)
+  ) {
+    return true;
+  }
+
+  return hasIdempotencyHeader(context.headers, config.idempotencyHeaderNames);
+};
+
 function callWithRetry<T>(
   fn: () => Promise<T>,
   config?: Partial<RetryConfig>,
+  context?: RetryRequestContext,
 ): Promise<T>;
 function callWithRetry<
   TData,
@@ -91,10 +194,12 @@ function callWithRetry<
 >(
   fn: () => RequestResult<TData, TError, ThrowOnError, TResponseStyle>,
   config?: Partial<RetryConfig>,
+  context?: RetryRequestContext,
 ): RequestResult<TData, TError, ThrowOnError, TResponseStyle>;
 async function callWithRetry<T>(
   fn: () => Promise<T>,
   config?: Partial<RetryConfig>,
+  context?: RetryRequestContext,
 ): Promise<T> {
   const retryConfig: RetryConfig = {
     ...DEFAULT_RETRY_CONFIG,
@@ -106,7 +211,12 @@ async function callWithRetry<T>(
     try {
       return await fn();
     } catch (error) {
-      if (!isRetryableError(error, retryConfig)) {
+      if (
+        !(
+          isRetryableError(error, retryConfig) &&
+          isRetryableRequest(context, retryConfig)
+        )
+      ) {
         throw error;
       }
 
@@ -132,12 +242,14 @@ async function callWithRetry<T>(
   });
 }
 
-export type { RetryConfig };
+export type { RetryConfig, RetryHttpMethod, RetryRequestContext };
 export {
   calculateRetryDelay,
   callWithRetry,
   DEFAULT_RETRY_CONFIG,
+  hasIdempotencyHeader,
   isRetryableError,
+  isRetryableRequest,
   isRetryableStatus,
   sleep,
 };

--- a/src/attio/schema.ts
+++ b/src/attio/schema.ts
@@ -28,6 +28,10 @@ import {
   getFirstValueSafe,
   getValue,
 } from "./values";
+import {
+  type AttioWriteValuesBuilder,
+  createWriteValuesBuilder,
+} from "./write-values";
 
 type SchemaTarget = GetV2ByTargetByIdentifierAttributesData["path"]["target"];
 type SchemaIdentifier =
@@ -70,7 +74,7 @@ interface AttributeAccessor {
   firstValueTyped: (record: AttioRecordLike) => unknown | undefined;
 }
 
-interface AttioSchema {
+interface AttioSchema extends AttioWriteValuesBuilder {
   target: SchemaTarget;
   identifier: SchemaIdentifier;
   attributes: ZodAttribute[];
@@ -204,11 +208,17 @@ const createSchema = async (input: SchemaInput): Promise<AttioSchema> => {
   const getAccessorOrThrow = (slug: string) =>
     createAccessor(getAttributeOrThrow(slug));
 
+  const writeValuesBuilder = createWriteValuesBuilder({
+    ...input,
+    attributes,
+  });
+
   return {
     target: input.target,
     identifier: input.identifier,
     attributes,
     attributeSlugs,
+    buildValues: writeValuesBuilder.buildValues,
     getAttribute,
     getAttributeOrThrow,
     getAccessor,

--- a/src/attio/values.ts
+++ b/src/attio/values.ts
@@ -540,5 +540,6 @@ export {
   getStatusTitles,
   getValue,
   getValueSafe,
+  locationInputSchema,
   value,
 };

--- a/src/attio/write-value-serializer.ts
+++ b/src/attio/write-value-serializer.ts
@@ -1,0 +1,360 @@
+import { z } from "zod";
+import { AttioResponseError } from "./errors";
+import type { NormalizedAllowedValue, ZodAttribute } from "./metadata";
+import { locationInputSchema, value } from "./values";
+import type { SchemaWriteOptions, SchemaWriteValue } from "./write-value-types";
+
+interface SerializeParams {
+  attribute: ZodAttribute;
+  entry: Exclude<SchemaWriteValue, null | undefined>;
+  options: Required<SchemaWriteOptions>;
+  getAllowedValues: (
+    attribute: ZodAttribute,
+  ) => Promise<NormalizedAllowedValue[]>;
+}
+
+type AttributeType = Exclude<ZodAttribute["type"], null>;
+type ObjectSerializer = (entry: unknown) => unknown[];
+type PrimitiveSerializer = (
+  entry: unknown,
+  attribute: ZodAttribute,
+) => unknown[];
+
+const defaultSchemaWriteOptions: Required<SchemaWriteOptions> = {
+  validateAllowedValues: true,
+  includeArchivedAllowedValues: false,
+};
+
+const nonEmptyStringSchema = z.string().min(1, "Expected a non-empty string.");
+const rawValueObjectSchema = z
+  .object({})
+  .passthrough()
+  .superRefine((item, ctx) => {
+    if (Object.keys(item).length === 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Expected a non-empty value object.",
+      });
+    }
+  });
+const dateLikeSchema = z.union([z.string(), z.date()]);
+const recordReferenceInputSchema = z.object({
+  targetObject: nonEmptyStringSchema,
+  targetRecordId: nonEmptyStringSchema,
+});
+const rawRecordReferenceInputSchema = z
+  .object({
+    target_object: nonEmptyStringSchema,
+    target_record_id: nonEmptyStringSchema,
+  })
+  .passthrough();
+const selectInputSchema = z
+  .object({
+    option: nonEmptyStringSchema,
+  })
+  .passthrough();
+const statusInputSchema = z
+  .object({
+    status: nonEmptyStringSchema,
+  })
+  .passthrough();
+const currencyInputSchema = z.object({
+  value: z.number().finite(),
+  currencyCode: z.string().optional(),
+});
+const rawCurrencyInputSchema = z
+  .object({
+    currency_value: z.number().finite(),
+    currency_code: z.string().optional(),
+  })
+  .passthrough();
+const phoneInputSchema = z.object({
+  original_phone_number: nonEmptyStringSchema,
+  country_code: z.string().optional(),
+});
+const personalNameInputSchema = z.object({
+  first_name: nonEmptyStringSchema.optional(),
+  last_name: nonEmptyStringSchema.optional(),
+  full_name: nonEmptyStringSchema.optional(),
+});
+const normalizeDateLike = (
+  input: string | Date,
+  type: "date" | "timestamp",
+) => {
+  if (typeof input === "string") {
+    return input;
+  }
+
+  const iso = input.toISOString();
+  return type === "date" ? iso.slice(0, 10) : iso;
+};
+
+const parseRawValueObject = (entry: unknown): Record<string, unknown> => {
+  const parsed = rawValueObjectSchema.safeParse(entry);
+  if (!parsed.success) {
+    throw new AttioResponseError("Unsupported write value.", {
+      code: "UNSUPPORTED_WRITE_VALUE",
+      data: parsed.error,
+    });
+  }
+  return parsed.data;
+};
+
+const assertAllowedValue = async ({
+  attribute,
+  value: candidate,
+  options,
+  getAllowedValues,
+}: {
+  attribute: ZodAttribute;
+  value: string;
+  options: Required<SchemaWriteOptions>;
+  getAllowedValues: (
+    attribute: ZodAttribute,
+  ) => Promise<NormalizedAllowedValue[]>;
+}): Promise<void> => {
+  if (!options.validateAllowedValues) {
+    return;
+  }
+
+  const allowedValues = await getAllowedValues(attribute);
+  const match = allowedValues.find(
+    (allowedValue) =>
+      allowedValue.id === candidate || allowedValue.title === candidate,
+  );
+
+  if (!match) {
+    throw new AttioResponseError(
+      `Unknown allowed value "${candidate}" for "${attribute.api_slug}".`,
+      {
+        code: "UNKNOWN_ALLOWED_VALUE",
+        data: { attribute: attribute.api_slug, value: candidate },
+      },
+    );
+  }
+
+  if (match.archived && !options.includeArchivedAllowedValues) {
+    throw new AttioResponseError(
+      `Allowed value "${candidate}" for "${attribute.api_slug}" is archived.`,
+      {
+        code: "ARCHIVED_ALLOWED_VALUE",
+        data: { attribute: attribute.api_slug, value: candidate },
+      },
+    );
+  }
+};
+
+const serializeRecordReference = (entry: unknown): unknown[] => {
+  const referenceInput = recordReferenceInputSchema.safeParse(entry);
+  if (referenceInput.success) {
+    return value.recordReference(referenceInput.data);
+  }
+
+  const rawReferenceInput = rawRecordReferenceInputSchema.safeParse(entry);
+  if (rawReferenceInput.success) {
+    return [rawReferenceInput.data];
+  }
+
+  return [parseRawValueObject(entry)];
+};
+
+const serializeCurrencyObject = (entry: unknown): unknown[] => {
+  const currencyInput = currencyInputSchema.safeParse(entry);
+  if (currencyInput.success) {
+    return value.currency(
+      currencyInput.data.value,
+      currencyInput.data.currencyCode,
+    );
+  }
+
+  const rawCurrencyInput = rawCurrencyInputSchema.safeParse(entry);
+  if (rawCurrencyInput.success) {
+    return [rawCurrencyInput.data];
+  }
+
+  return [parseRawValueObject(entry)];
+};
+
+const serializePhoneObject = (entry: unknown): unknown[] => {
+  const phoneInput = phoneInputSchema.safeParse(entry);
+  if (!phoneInput.success) {
+    return [parseRawValueObject(entry)];
+  }
+
+  return value.phone(
+    phoneInput.data.original_phone_number,
+    phoneInput.data.country_code,
+  );
+};
+
+const serializePersonalNameObject = (entry: unknown): unknown[] => {
+  const personalNameInput = personalNameInputSchema.safeParse(entry);
+  if (!personalNameInput.success) {
+    return [parseRawValueObject(entry)];
+  }
+
+  return value.personalName(personalNameInput.data);
+};
+
+const serializeLocationObject = (entry: unknown): unknown[] => {
+  const locationInput = locationInputSchema.safeParse(entry);
+  if (!locationInput.success) {
+    return [parseRawValueObject(entry)];
+  }
+
+  return value.location(locationInput.data);
+};
+
+const objectSerializers: Partial<Record<AttributeType, ObjectSerializer>> = {
+  currency: serializeCurrencyObject,
+  location: serializeLocationObject,
+  "personal-name": serializePersonalNameObject,
+  "phone-number": serializePhoneObject,
+  "record-reference": serializeRecordReference,
+};
+
+const serializeObjectValue = (attribute: ZodAttribute, entry: unknown) => {
+  const serializer = attribute.type
+    ? objectSerializers[attribute.type]
+    : undefined;
+  if (!serializer) {
+    return [parseRawValueObject(entry)];
+  }
+
+  return serializer(entry);
+};
+
+const serializeBooleanPrimitive = (entry: unknown) =>
+  value.boolean(z.boolean().parse(entry));
+
+const serializeCurrencyPrimitive = (
+  entry: unknown,
+  attribute: ZodAttribute,
+) => {
+  const currencyCode =
+    attribute.config.currency.default_currency_code ?? undefined;
+  return value.currency(z.number().finite().parse(entry), currencyCode);
+};
+
+const serializeDatePrimitive = (entry: unknown) =>
+  value.string(normalizeDateLike(dateLikeSchema.parse(entry), "date"));
+
+const serializeDomainPrimitive = (entry: unknown) =>
+  value.domain(nonEmptyStringSchema.parse(entry));
+
+const serializeEmailPrimitive = (entry: unknown) =>
+  value.email(nonEmptyStringSchema.parse(entry));
+
+const serializeNumberPrimitive = (entry: unknown) =>
+  value.number(z.number().finite().parse(entry));
+
+const serializePhonePrimitive = (entry: unknown) =>
+  value.phone(nonEmptyStringSchema.parse(entry));
+
+const serializeTextPrimitive = (entry: unknown) =>
+  value.string(nonEmptyStringSchema.parse(entry));
+
+const serializeTimestampPrimitive = (entry: unknown) =>
+  value.string(normalizeDateLike(dateLikeSchema.parse(entry), "timestamp"));
+
+const primitiveSerializers: Partial<
+  Record<AttributeType, PrimitiveSerializer>
+> = {
+  checkbox: serializeBooleanPrimitive,
+  currency: serializeCurrencyPrimitive,
+  date: serializeDatePrimitive,
+  domain: serializeDomainPrimitive,
+  "email-address": serializeEmailPrimitive,
+  number: serializeNumberPrimitive,
+  "phone-number": serializePhonePrimitive,
+  rating: serializeNumberPrimitive,
+  text: serializeTextPrimitive,
+  timestamp: serializeTimestampPrimitive,
+};
+
+const serializePrimitiveValue = ({
+  attribute,
+  entry,
+}: Pick<SerializeParams, "attribute" | "entry">): unknown[] => {
+  if (attribute.type === null) {
+    return serializeTextPrimitive(entry);
+  }
+
+  const serializer = primitiveSerializers[attribute.type];
+  if (serializer) {
+    return serializer(entry, attribute);
+  }
+
+  throw new AttioResponseError(
+    `Attribute "${attribute.api_slug}" requires object values.`,
+    {
+      code: "UNSUPPORTED_WRITE_VALUE",
+      data: { attribute: attribute.api_slug, type: attribute.type },
+    },
+  );
+};
+
+const parseChoiceInput = (
+  attribute: ZodAttribute,
+  entry: Exclude<SchemaWriteValue, null | undefined>,
+): { selected: string; rawValue?: Record<string, unknown> } => {
+  if (attribute.type === "status") {
+    const statusInput = statusInputSchema.safeParse(entry);
+    if (statusInput.success) {
+      return { selected: statusInput.data.status, rawValue: statusInput.data };
+    }
+  }
+
+  if (attribute.type === "select") {
+    const selectInput = selectInputSchema.safeParse(entry);
+    if (selectInput.success) {
+      return { selected: selectInput.data.option, rawValue: selectInput.data };
+    }
+  }
+
+  return { selected: nonEmptyStringSchema.parse(entry) };
+};
+
+const serializeChoiceValue = async ({
+  attribute,
+  entry,
+  options,
+  getAllowedValues,
+}: SerializeParams): Promise<unknown[]> => {
+  const choiceInput = parseChoiceInput(attribute, entry);
+
+  await assertAllowedValue({
+    attribute,
+    value: choiceInput.selected,
+    options,
+    getAllowedValues,
+  });
+
+  if (choiceInput.rawValue) {
+    return [choiceInput.rawValue];
+  }
+
+  return attribute.type === "status"
+    ? value.status(choiceInput.selected)
+    : value.select(choiceInput.selected);
+};
+
+const serializeAttributeEntry = async (
+  params: SerializeParams,
+): Promise<unknown[]> => {
+  if (
+    params.attribute.type === "select" ||
+    params.attribute.type === "status"
+  ) {
+    return await serializeChoiceValue(params);
+  }
+
+  const objectResult = rawValueObjectSchema.safeParse(params.entry);
+  if (objectResult.success) {
+    return serializeObjectValue(params.attribute, objectResult.data);
+  }
+
+  return serializePrimitiveValue(params);
+};
+
+export { defaultSchemaWriteOptions, serializeAttributeEntry };

--- a/src/attio/write-value-types.ts
+++ b/src/attio/write-value-types.ts
@@ -1,0 +1,30 @@
+type WriteValueScalar = string | number | boolean | Date;
+type SchemaWriteValue =
+  | WriteValueScalar
+  | Record<string, unknown>
+  | null
+  | undefined;
+type SchemaWriteFieldValue = SchemaWriteValue | SchemaWriteValue[];
+type SchemaWriteInput = Record<string, SchemaWriteFieldValue>;
+type SchemaWriteValues = Record<string, unknown[]>;
+
+interface SchemaWriteOptions {
+  validateAllowedValues?: boolean;
+  includeArchivedAllowedValues?: boolean;
+}
+
+interface AttioWriteValuesBuilder {
+  buildValues: (
+    input: SchemaWriteInput,
+    options?: SchemaWriteOptions,
+  ) => Promise<SchemaWriteValues>;
+}
+
+export type {
+  AttioWriteValuesBuilder,
+  SchemaWriteFieldValue,
+  SchemaWriteInput,
+  SchemaWriteOptions,
+  SchemaWriteValue,
+  SchemaWriteValues,
+};

--- a/src/attio/write-values.ts
+++ b/src/attio/write-values.ts
@@ -1,0 +1,296 @@
+import { z } from "zod";
+import type { AttioClientInput } from "./client";
+import { AttioResponseError } from "./errors";
+import {
+  type AttributeIdentifier,
+  type AttributeTarget,
+  type ListAllowedValuesInput,
+  listAllowedValues,
+  type NormalizedAllowedValue,
+  type ZodAttribute,
+} from "./metadata";
+import {
+  defaultSchemaWriteOptions,
+  serializeAttributeEntry,
+} from "./write-value-serializer";
+import type {
+  AttioWriteValuesBuilder,
+  SchemaWriteFieldValue,
+  SchemaWriteOptions,
+  SchemaWriteValue,
+  SchemaWriteValues,
+} from "./write-value-types";
+
+interface CreateWriteValuesBuilderInput extends AttioClientInput {
+  target: AttributeTarget;
+  identifier: AttributeIdentifier;
+  attributes: readonly ZodAttribute[];
+  options?: ListAllowedValuesInput["options"];
+  allowedValueResolver?: (
+    input: ListAllowedValuesInput,
+  ) => Promise<NormalizedAllowedValue[]>;
+}
+
+interface AttributeLookup {
+  bySlug: Map<string, ZodAttribute>;
+  byTitle: Map<string, ZodAttribute>;
+  ambiguousTitles: Set<string>;
+}
+
+type AllowedValueResolver = (
+  input: ListAllowedValuesInput,
+) => Promise<NormalizedAllowedValue[]>;
+
+type AllowedValueGetterInput = Omit<
+  CreateWriteValuesBuilderInput,
+  "allowedValueResolver" | "attributes"
+> & {
+  allowedValueResolver: AllowedValueResolver;
+};
+
+const createAttributeLookup = (
+  attributes: readonly ZodAttribute[],
+): AttributeLookup => {
+  const bySlug = new Map<string, ZodAttribute>();
+  const byTitle = new Map<string, ZodAttribute>();
+  const ambiguousTitles = new Set<string>();
+
+  for (const attribute of attributes) {
+    bySlug.set(attribute.api_slug, attribute);
+
+    if (byTitle.has(attribute.title)) {
+      ambiguousTitles.add(attribute.title);
+      byTitle.delete(attribute.title);
+    } else if (!ambiguousTitles.has(attribute.title)) {
+      byTitle.set(attribute.title, attribute);
+    }
+  }
+
+  return { bySlug, byTitle, ambiguousTitles };
+};
+
+const resolveAttribute = (
+  lookup: AttributeLookup,
+  key: string,
+): ZodAttribute => {
+  const slugAttribute = lookup.bySlug.get(key);
+  if (slugAttribute) {
+    return slugAttribute;
+  }
+
+  if (lookup.ambiguousTitles.has(key)) {
+    throw new AttioResponseError(`Ambiguous attribute title "${key}".`, {
+      code: "AMBIGUOUS_ATTRIBUTE_TITLE",
+      data: { title: key },
+    });
+  }
+
+  const titleAttribute = lookup.byTitle.get(key);
+  if (titleAttribute) {
+    return titleAttribute;
+  }
+
+  throw new AttioResponseError(`Unknown attribute "${key}".`, {
+    code: "UNKNOWN_ATTRIBUTE",
+    data: { attribute: key },
+  });
+};
+
+const assertWritableAttribute = (attribute: ZodAttribute): void => {
+  if (!attribute.is_writable) {
+    throw new AttioResponseError(
+      `Attribute "${attribute.api_slug}" is not writable.`,
+      {
+        code: "NON_WRITABLE_ATTRIBUTE",
+        data: { attribute: attribute.api_slug },
+      },
+    );
+  }
+};
+
+const normalizeWriteFieldValue = (
+  valueInput: SchemaWriteFieldValue,
+): SchemaWriteValue[] | null | undefined => {
+  if (valueInput === undefined) {
+    return;
+  }
+
+  if (valueInput === null) {
+    return null;
+  }
+
+  return Array.isArray(valueInput) ? valueInput : [valueInput];
+};
+
+const createAllowedValueGetter = ({
+  client,
+  config,
+  target,
+  identifier,
+  options,
+  allowedValueResolver,
+}: AllowedValueGetterInput) => {
+  const allowedValueCache = new Map<
+    string,
+    Promise<NormalizedAllowedValue[]>
+  >();
+
+  return (attribute: ZodAttribute) => {
+    const cacheKey = attribute.api_slug;
+    const cached = allowedValueCache.get(cacheKey);
+    if (cached) {
+      return cached;
+    }
+
+    const promise = allowedValueResolver({
+      client,
+      config,
+      target,
+      identifier,
+      attribute: attribute.api_slug,
+      type: attribute.type === "status" ? "status" : "select",
+      options,
+    });
+    allowedValueCache.set(cacheKey, promise);
+    return promise;
+  };
+};
+
+const serializeEntries = async ({
+  attribute,
+  entries,
+  options,
+  getAllowedValues,
+}: {
+  attribute: ZodAttribute;
+  entries: SchemaWriteValue[];
+  options: Required<SchemaWriteOptions>;
+  getAllowedValues: (
+    attribute: ZodAttribute,
+  ) => Promise<NormalizedAllowedValue[]>;
+}): Promise<unknown[]> => {
+  const serializedEntries: unknown[] = [];
+
+  for (const entry of entries) {
+    if (entry !== undefined && entry !== null) {
+      try {
+        serializedEntries.push(
+          ...(await serializeAttributeEntry({
+            attribute,
+            entry,
+            options,
+            getAllowedValues,
+          })),
+        );
+      } catch (error) {
+        if (error instanceof z.ZodError) {
+          throw new AttioResponseError(
+            `Invalid write value for "${attribute.api_slug}".`,
+            {
+              code: "INVALID_WRITE_VALUE",
+              data: error,
+            },
+          );
+        }
+        throw error;
+      }
+    }
+  }
+
+  return serializedEntries;
+};
+
+const buildFieldValues = async ({
+  lookup,
+  key,
+  fieldValue,
+  options,
+  getAllowedValues,
+}: {
+  lookup: AttributeLookup;
+  key: string;
+  fieldValue: SchemaWriteFieldValue;
+  options: Required<SchemaWriteOptions>;
+  getAllowedValues: (
+    attribute: ZodAttribute,
+  ) => Promise<NormalizedAllowedValue[]>;
+}): Promise<{ slug: string; values: unknown[] } | undefined> => {
+  const attribute = resolveAttribute(lookup, key);
+  assertWritableAttribute(attribute);
+
+  const entries = normalizeWriteFieldValue(fieldValue);
+  if (entries === undefined) {
+    return;
+  }
+
+  if (entries === null) {
+    return { slug: attribute.api_slug, values: [] };
+  }
+
+  const values = await serializeEntries({
+    attribute,
+    entries,
+    options,
+    getAllowedValues,
+  });
+  return { slug: attribute.api_slug, values };
+};
+
+const createWriteValuesBuilder = ({
+  target,
+  identifier,
+  attributes,
+  client,
+  config,
+  options,
+  allowedValueResolver = listAllowedValues,
+}: CreateWriteValuesBuilderInput): AttioWriteValuesBuilder => {
+  const lookup = createAttributeLookup(attributes);
+  const getAllowedValues = createAllowedValueGetter({
+    client,
+    config,
+    target,
+    identifier,
+    options,
+    allowedValueResolver,
+  });
+
+  const buildValues: AttioWriteValuesBuilder["buildValues"] = async (
+    input,
+    writeOptions,
+  ) => {
+    const resolvedOptions = {
+      ...defaultSchemaWriteOptions,
+      ...writeOptions,
+    };
+    const values: SchemaWriteValues = {};
+
+    for (const [key, fieldValue] of Object.entries(input)) {
+      const result = await buildFieldValues({
+        lookup,
+        key,
+        fieldValue,
+        options: resolvedOptions,
+        getAllowedValues,
+      });
+      if (result) {
+        values[result.slug] = result.values;
+      }
+    }
+
+    return values;
+  };
+
+  return { buildValues };
+};
+
+export type {
+  AttioWriteValuesBuilder,
+  SchemaWriteFieldValue,
+  SchemaWriteInput,
+  SchemaWriteOptions,
+  SchemaWriteValue,
+  SchemaWriteValues,
+} from "./write-value-types";
+export type { CreateWriteValuesBuilderInput };
+export { createWriteValuesBuilder };

--- a/test/attio/client.spec.ts
+++ b/test/attio/client.spec.ts
@@ -135,6 +135,83 @@ describe("wrapClient", () => {
     await client.request({ url: "/test", method: "GET" });
     expect(mockFetch).toHaveBeenCalledTimes(2);
   });
+
+  it("does not retry unsafe methods by default", async () => {
+    const mockFetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ error: "server error" }), {
+        status: 500,
+      }),
+    );
+
+    const client = createAttioClient({
+      authToken: TEST_TOKEN,
+      fetch: mockFetch,
+      retry: { maxRetries: 2, initialDelayMs: 1, maxDelayMs: 5 },
+    });
+
+    await expect(client.post({ url: "/test", body: {} })).rejects.toThrow();
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries unsafe methods when explicitly enabled", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: "server error" }), {
+          status: 500,
+        }),
+      )
+      .mockResolvedValue(
+        new Response(JSON.stringify({ data: "success" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+
+    const client = createAttioClient({
+      authToken: TEST_TOKEN,
+      fetch: mockFetch,
+      retry: { maxRetries: 2, initialDelayMs: 1, maxDelayMs: 5 },
+    });
+
+    await client.post({
+      url: "/test",
+      body: {},
+      retry: { retryUnsafeRequests: true },
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries unsafe methods with an idempotency header", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: "server error" }), {
+          status: 500,
+        }),
+      )
+      .mockResolvedValue(
+        new Response(JSON.stringify({ data: "success" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+
+    const client = createAttioClient({
+      authToken: TEST_TOKEN,
+      fetch: mockFetch,
+      retry: { maxRetries: 2, initialDelayMs: 1, maxDelayMs: 5 },
+    });
+
+    await client.post({
+      url: "/test",
+      body: {},
+      headers: { "Idempotency-Key": "create-company-1" },
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
 });
 
 describe("applyInterceptors", () => {

--- a/test/attio/errors.spec.ts
+++ b/test/attio/errors.spec.ts
@@ -9,9 +9,16 @@ import {
   AttioNetworkError,
   AttioResponseError,
   AttioRetryError,
+  getAttioErrorCode,
+  getAttioErrorPayload,
   getAttioErrorStatus,
+  getAttioErrorType,
+  isAttioAuthError,
   isAttioError,
   isAttioNotFound,
+  isAttioPermissionError,
+  isAttioRateLimitError,
+  isAttioValidationError,
   isRetryableAttioError,
   normalizeAttioError,
 } from "../../src/attio/errors";
@@ -202,6 +209,28 @@ describe("normalizeAttioError", () => {
     expect(error.type).toBe("validation_error");
   });
 
+  it("extracts details from nested Attio error payloads", () => {
+    const response = new Response(null, { status: 400 });
+    const payload = {
+      error: {
+        message: "Nested validation failed",
+        code: "validation_type",
+        type: "validation_error",
+        status_code: 422,
+      },
+      errors: [{ code: "validation_type" }],
+    };
+
+    const error = normalizeAttioError(payload, { response });
+
+    expect(error.message).toBe("Nested validation failed");
+    expect(error.code).toBe("validation_type");
+    expect(error.type).toBe("validation_error");
+    expect(error.status).toBe(400);
+    expect(error.data).toEqual(payload);
+    expect(error.errors).toEqual([{ code: "validation_type" }]);
+  });
+
   it("extracts status_code from payload", () => {
     const error = normalizeAttioError({
       message: "Error",
@@ -350,9 +379,42 @@ describe("stable error helpers", () => {
     expect(getAttioErrorStatus({ status_code: 422 })).toBe(422);
   });
 
+  it("extracts code, type, and payload from nested error shapes", () => {
+    const payload = {
+      error: {
+        message: "missing",
+        code: "not_found",
+        type: "invalid_request_error",
+        status_code: 404,
+      },
+    };
+
+    expect(getAttioErrorStatus(payload)).toBe(404);
+    expect(getAttioErrorCode(payload)).toBe("not_found");
+    expect(getAttioErrorType(payload)).toBe("invalid_request_error");
+    expect(getAttioErrorPayload(payload)).toMatchObject({
+      code: "not_found",
+      status_code: 404,
+    });
+  });
+
   it("detects not found errors", () => {
     expect(isAttioNotFound({ name: "AttioApiError", status: 404 })).toBe(true);
+    expect(isAttioNotFound({ code: "not_found" })).toBe(true);
     expect(isAttioNotFound({ name: "AttioApiError", status: 400 })).toBe(false);
+  });
+
+  it("detects specialized API error classes by status, type, or code", () => {
+    expect(isAttioAuthError({ status: 401 })).toBe(true);
+    expect(isAttioAuthError({ type: "auth_error" })).toBe(true);
+    expect(isAttioPermissionError({ status: 403 })).toBe(true);
+    expect(isAttioPermissionError({ code: "system_edit_unauthorized" })).toBe(
+      true,
+    );
+    expect(isAttioRateLimitError({ status: 429 })).toBe(true);
+    expect(isAttioRateLimitError({ code: "rate_limited" })).toBe(true);
+    expect(isAttioValidationError({ status: 422 })).toBe(true);
+    expect(isAttioValidationError({ code: "validation_type" })).toBe(true);
   });
 
   it("detects retryable Attio failures", () => {

--- a/test/attio/retry.spec.ts
+++ b/test/attio/retry.spec.ts
@@ -4,7 +4,9 @@ import {
   calculateRetryDelay,
   callWithRetry,
   DEFAULT_RETRY_CONFIG,
+  hasIdempotencyHeader,
   isRetryableError,
+  isRetryableRequest,
   isRetryableStatus,
   type RetryConfig,
   sleep,
@@ -15,7 +17,10 @@ const config: RetryConfig = {
   initialDelayMs: 500,
   maxDelayMs: 5000,
   retryableStatusCodes: [408, 429, 500],
+  retryableMethods: ["GET", "HEAD", "OPTIONS"],
   respectRetryAfter: true,
+  retryUnsafeRequests: false,
+  idempotencyHeaderNames: ["Idempotency-Key", "X-Idempotency-Key"],
 };
 
 afterEach(() => {
@@ -92,6 +97,62 @@ describe("retry", () => {
 
     it("treats undefined errors as retryable", () => {
       expect(isRetryableError(undefined, config)).toBe(true);
+    });
+  });
+
+  describe("isRetryableRequest", () => {
+    it("allows configured retryable methods", () => {
+      expect(isRetryableRequest({ method: "GET" }, config)).toBe(true);
+      expect(isRetryableRequest({ method: "HEAD" }, config)).toBe(true);
+      expect(isRetryableRequest({ method: "POST" }, config)).toBe(false);
+    });
+
+    it("allows non-idempotent methods with an idempotency header", () => {
+      expect(
+        isRetryableRequest(
+          {
+            method: "POST",
+            headers: { "Idempotency-Key": "create-company-1" },
+          },
+          config,
+        ),
+      ).toBe(true);
+    });
+
+    it("allows all methods when retryUnsafeRequests is enabled", () => {
+      expect(
+        isRetryableRequest(
+          { method: "POST" },
+          { ...config, retryUnsafeRequests: true },
+        ),
+      ).toBe(true);
+    });
+
+    it("preserves utility behavior when no request method is provided", () => {
+      expect(isRetryableRequest(undefined, config)).toBe(true);
+    });
+  });
+
+  describe("hasIdempotencyHeader", () => {
+    it("detects idempotency headers from Headers and object inputs", () => {
+      expect(
+        hasIdempotencyHeader(
+          new Headers({ "Idempotency-Key": "request-1" }),
+          config.idempotencyHeaderNames,
+        ),
+      ).toBe(true);
+      expect(
+        hasIdempotencyHeader(
+          { "X-Idempotency-Key": "request-2" },
+          config.idempotencyHeaderNames,
+        ),
+      ).toBe(true);
+      expect(
+        hasIdempotencyHeader(
+          { "X-Other-Header": "request-3" },
+          config.idempotencyHeaderNames,
+        ),
+      ).toBe(false);
     });
   });
 
@@ -175,7 +236,16 @@ describe("retry", () => {
       expect(DEFAULT_RETRY_CONFIG.initialDelayMs).toBe(500);
       expect(DEFAULT_RETRY_CONFIG.maxDelayMs).toBe(5000);
       expect(DEFAULT_RETRY_CONFIG.retryableStatusCodes).toContain(429);
+      expect(DEFAULT_RETRY_CONFIG.retryableMethods).toEqual([
+        "GET",
+        "HEAD",
+        "OPTIONS",
+      ]);
       expect(DEFAULT_RETRY_CONFIG.respectRetryAfter).toBe(true);
+      expect(DEFAULT_RETRY_CONFIG.retryUnsafeRequests).toBe(false);
+      expect(DEFAULT_RETRY_CONFIG.idempotencyHeaderNames).toContain(
+        "Idempotency-Key",
+      );
     });
   });
 });

--- a/test/attio/schema.spec.ts
+++ b/test/attio/schema.spec.ts
@@ -1,11 +1,16 @@
 import { describe, expect, it, vi } from "vitest";
 import { z } from "zod";
 import { AttioResponseError } from "../../src/attio/errors";
-import { listAttributes, type ZodAttribute } from "../../src/attio/metadata";
+import {
+  listAllowedValues,
+  listAttributes,
+  type ZodAttribute,
+} from "../../src/attio/metadata";
 import { createSchema } from "../../src/attio/schema";
 
 vi.mock("../../src/attio/metadata", () => ({
   listAttributes: vi.fn(),
+  listAllowedValues: vi.fn(),
 }));
 
 interface MockAttributeInput {
@@ -82,6 +87,30 @@ describe("createSchema", () => {
 
     const strictAccessor = schema.getAccessorOrThrow("name");
     expect(strictAccessor.attribute.api_slug).toBe("name");
+  });
+
+  it("builds schema-bound write values", async () => {
+    const mockList = vi.mocked(listAttributes);
+    const mockAllowedValues = vi.mocked(listAllowedValues);
+    mockList.mockResolvedValue([
+      mockAttribute({ slug: "name", type: "text" }),
+      mockAttribute({ slug: "stage", type: "select" }),
+    ]);
+    mockAllowedValues.mockResolvedValue([
+      { id: "opt_1", title: "Prospect", archived: false },
+    ]);
+
+    const schema = await createSchema({
+      target: "objects",
+      identifier: "companies",
+    });
+
+    await expect(
+      schema.buildValues({ name: "Acme", stage: "Prospect" }),
+    ).resolves.toEqual({
+      name: [{ value: "Acme" }],
+      stage: [{ option: "Prospect" }],
+    });
   });
 
   it("throws when attribute slug is unknown", async () => {

--- a/test/attio/write-values.spec.ts
+++ b/test/attio/write-values.spec.ts
@@ -1,0 +1,281 @@
+import { describe, expect, it, vi } from "vitest";
+import { AttioResponseError } from "../../src/attio/errors";
+import type {
+  NormalizedAllowedValue,
+  ZodAttribute,
+} from "../../src/attio/metadata";
+import { createWriteValuesBuilder } from "../../src/attio/write-values";
+
+interface MockAttributeInput {
+  slug: string;
+  title?: string;
+  type: ZodAttribute["type"];
+  writable?: boolean;
+  defaultCurrencyCode?: "USD" | "EUR" | null;
+}
+
+const mockAttribute = ({
+  slug,
+  title = slug,
+  type,
+  writable = true,
+  defaultCurrencyCode = "USD",
+}: MockAttributeInput): ZodAttribute => ({
+  id: {
+    workspace_id: "550e8400-e29b-41d4-a716-446655440000",
+    object_id: "550e8400-e29b-41d4-a716-446655440001",
+    attribute_id: `550e8400-e29b-41d4-a716-44665544${slug.padStart(4, "0").slice(0, 4)}`,
+  },
+  title,
+  description: null,
+  api_slug: slug,
+  type,
+  is_system_attribute: false,
+  is_writable: writable,
+  is_required: false,
+  is_unique: false,
+  is_multiselect: false,
+  is_default_value_enabled: false,
+  is_archived: false,
+  default_value: null,
+  relationship: null,
+  created_at: "2024-01-01T00:00:00Z",
+  config: {
+    currency: {
+      default_currency_code: defaultCurrencyCode,
+      display_type: "code",
+    },
+    record_reference: { allowed_object_ids: null },
+  },
+});
+
+const allowedValues = (
+  values: Array<
+    Pick<NormalizedAllowedValue, "id" | "title"> & { archived?: boolean }
+  >,
+): NormalizedAllowedValue[] =>
+  values.map((entry) => ({
+    id: entry.id,
+    title: entry.title,
+    archived: entry.archived ?? false,
+  }));
+
+describe("createWriteValuesBuilder", () => {
+  it("resolves titles and slugs, then serializes native values", async () => {
+    const builder = createWriteValuesBuilder({
+      target: "objects",
+      identifier: "companies",
+      attributes: [
+        mockAttribute({ slug: "name", title: "Name", type: "text" }),
+        mockAttribute({ slug: "website", title: "Website", type: "domain" }),
+        mockAttribute({ slug: "employees", type: "number" }),
+        mockAttribute({ slug: "active", title: "Active", type: "checkbox" }),
+        mockAttribute({ slug: "founded", title: "Founded", type: "date" }),
+        mockAttribute({
+          slug: "updated_at",
+          title: "Updated At",
+          type: "timestamp",
+        }),
+        mockAttribute({ slug: "revenue", title: "Revenue", type: "currency" }),
+      ],
+    });
+
+    const values = await builder.buildValues({
+      Name: "Acme",
+      Website: "acme.com",
+      employees: 42,
+      Active: true,
+      Founded: new Date("2024-01-02T10:15:00.000Z"),
+      "Updated At": new Date("2024-01-02T10:15:00.000Z"),
+      Revenue: 12_500,
+    });
+
+    expect(values).toEqual({
+      name: [{ value: "Acme" }],
+      website: [{ domain: "acme.com" }],
+      employees: [{ value: 42 }],
+      active: [{ value: true }],
+      founded: [{ value: "2024-01-02" }],
+      updated_at: [{ value: "2024-01-02T10:15:00.000Z" }],
+      revenue: [{ currency_value: 12_500, currency_code: "USD" }],
+    });
+  });
+
+  it("validates select and status values against metadata", async () => {
+    const allowedValueResolver = vi.fn(async ({ attribute }) => {
+      if (attribute === "stage") {
+        return allowedValues([{ id: "opt_1", title: "Prospect" }]);
+      }
+      return allowedValues([{ id: "sta_1", title: "Customer" }]);
+    });
+    const builder = createWriteValuesBuilder({
+      target: "objects",
+      identifier: "companies",
+      attributes: [
+        mockAttribute({ slug: "stage", title: "Stage", type: "select" }),
+        mockAttribute({ slug: "status", title: "Status", type: "status" }),
+      ],
+      allowedValueResolver,
+    });
+
+    const values = await builder.buildValues({
+      Stage: "Prospect",
+      Status: "Customer",
+    });
+
+    expect(values).toEqual({
+      stage: [{ option: "Prospect" }],
+      status: [{ status: "Customer" }],
+    });
+    expect(allowedValueResolver).toHaveBeenCalledTimes(2);
+  });
+
+  it("accepts existing value factory arrays and record reference objects", async () => {
+    const allowedValueResolver = vi.fn(async () =>
+      allowedValues([{ id: "opt_1", title: "Prospect" }]),
+    );
+    const builder = createWriteValuesBuilder({
+      target: "objects",
+      identifier: "companies",
+      attributes: [
+        mockAttribute({ slug: "stage", title: "Stage", type: "select" }),
+        mockAttribute({
+          slug: "parent_company",
+          title: "Parent Company",
+          type: "record-reference",
+        }),
+      ],
+      allowedValueResolver,
+    });
+
+    const values = await builder.buildValues({
+      Stage: [{ option: "Prospect" }],
+      "Parent Company": {
+        targetObject: "companies",
+        targetRecordId: "rec_123",
+      },
+    });
+
+    expect(values).toEqual({
+      stage: [{ option: "Prospect" }],
+      parent_company: [
+        {
+          target_object: "companies",
+          target_record_id: "rec_123",
+        },
+      ],
+    });
+  });
+
+  it("uses null to clear a field and skips undefined fields", async () => {
+    const builder = createWriteValuesBuilder({
+      target: "objects",
+      identifier: "companies",
+      attributes: [
+        mockAttribute({ slug: "name", title: "Name", type: "text" }),
+        mockAttribute({ slug: "website", title: "Website", type: "domain" }),
+      ],
+    });
+
+    await expect(
+      builder.buildValues({ Name: null, Website: undefined }),
+    ).resolves.toEqual({ name: [] });
+  });
+
+  it("rejects non-writable and ambiguous attributes", async () => {
+    const nonWritableBuilder = createWriteValuesBuilder({
+      target: "objects",
+      identifier: "companies",
+      attributes: [
+        mockAttribute({
+          slug: "created_at",
+          title: "Created At",
+          type: "timestamp",
+          writable: false,
+        }),
+      ],
+    });
+
+    await expect(
+      nonWritableBuilder.buildValues({ "Created At": new Date() }),
+    ).rejects.toMatchObject({ code: "NON_WRITABLE_ATTRIBUTE" });
+
+    const ambiguousBuilder = createWriteValuesBuilder({
+      target: "objects",
+      identifier: "companies",
+      attributes: [
+        mockAttribute({ slug: "stage_a", title: "Stage", type: "select" }),
+        mockAttribute({ slug: "stage_b", title: "Stage", type: "select" }),
+      ],
+    });
+
+    await expect(
+      ambiguousBuilder.buildValues({ Stage: "Prospect" }),
+    ).rejects.toMatchObject({ code: "AMBIGUOUS_ATTRIBUTE_TITLE" });
+  });
+
+  it("rejects unknown or archived allowed values unless configured otherwise", async () => {
+    const allowedValueResolver = vi.fn(async () =>
+      allowedValues([{ id: "opt_1", title: "Prospect", archived: true }]),
+    );
+    const builder = createWriteValuesBuilder({
+      target: "objects",
+      identifier: "companies",
+      attributes: [
+        mockAttribute({ slug: "stage", title: "Stage", type: "select" }),
+      ],
+      allowedValueResolver,
+    });
+
+    await expect(
+      builder.buildValues({ Stage: "Missing" }),
+    ).rejects.toMatchObject({ code: "UNKNOWN_ALLOWED_VALUE" });
+    await expect(
+      builder.buildValues({ Stage: "Prospect" }),
+    ).rejects.toMatchObject({ code: "ARCHIVED_ALLOWED_VALUE" });
+
+    await expect(
+      builder.buildValues(
+        { Stage: "Prospect" },
+        { includeArchivedAllowedValues: true },
+      ),
+    ).resolves.toEqual({ stage: [{ option: "Prospect" }] });
+  });
+
+  it("can disable allowed value validation for select and status fields", async () => {
+    const allowedValueResolver = vi.fn();
+    const builder = createWriteValuesBuilder({
+      target: "objects",
+      identifier: "companies",
+      attributes: [
+        mockAttribute({ slug: "stage", title: "Stage", type: "select" }),
+      ],
+      allowedValueResolver,
+    });
+
+    await expect(
+      builder.buildValues(
+        { Stage: "Locally Created" },
+        { validateAllowedValues: false },
+      ),
+    ).resolves.toEqual({ stage: [{ option: "Locally Created" }] });
+    expect(allowedValueResolver).not.toHaveBeenCalled();
+  });
+
+  it("wraps invalid native values in AttioResponseError", async () => {
+    const builder = createWriteValuesBuilder({
+      target: "objects",
+      identifier: "companies",
+      attributes: [
+        mockAttribute({ slug: "email", title: "Email", type: "email-address" }),
+      ],
+    });
+
+    await expect(
+      builder.buildValues({ Email: "not-an-email" }),
+    ).rejects.toThrow(AttioResponseError);
+    await expect(
+      builder.buildValues({ Email: "not-an-email" }),
+    ).rejects.toMatchObject({ code: "INVALID_WRITE_VALUE" });
+  });
+});


### PR DESCRIPTION
Retry only idempotent methods by default unless a request opts in.

Honor idempotency headers for unsafe method retries.

Add Attio error helpers with nested payload extraction.

Add schema-bound buildValues for metadata-aware writes.

Model: GPT-5
Reasoning: default
Thread: 019e22c3-0576-7b83-959a-8d29976aa21a

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add schema-aware write builder and safer retries for unsafe HTTP methods
> - Introduces `createWriteValuesBuilder` in [write-values.ts](https://github.com/hbmartin/attio-ts-sdk/pull/157/files#diff-04124700c872841053b757e4eabf31263a192a986e1d912e39a5883570a1645a) and [write-value-serializer.ts](https://github.com/hbmartin/attio-ts-sdk/pull/157/files#diff-c6942a49356980e511be6cd8d152730a0f005863a54bab06d96288137d127e7f), enabling validated, metadata-driven serialization of Attio record write payloads from attribute titles or slugs, including select/status allowed-value validation.
> - Extends `AttioSchema` with a `buildValues` method via [schema.ts](https://github.com/hbmartin/attio-ts-sdk/pull/157/files#diff-289e7ed0a1f263d6270fed07a4b17df4391dbef4702712c647a04b796818d788), so callers can serialize native JS values directly on a schema object.
> - Adds `isRetryableRequest` in [retry.ts](https://github.com/hbmartin/attio-ts-sdk/pull/157/files#diff-573794750310b4901be10068ac92c3ad1cb5b4048f7c6604ef7e5a81b0122a82) to limit retries to safe HTTP methods (GET, HEAD, OPTIONS) by default; unsafe methods are only retried when `retryUnsafeRequests` is enabled or an idempotency header is present.
> - Adds new error classification helpers (`isAttioAuthError`, `isAttioPermissionError`, `isAttioRateLimitError`, `isAttioValidationError`) and improves nested error payload extraction in [errors.ts](https://github.com/hbmartin/attio-ts-sdk/pull/157/files#diff-04f0a9359a4656765ea144a17d039c333e7c22700e807dbbcdcdb4ea13301b12).
> - Behavioral Change: prior behavior retried all failed requests regardless of HTTP method; unsafe methods (POST, PATCH, DELETE, etc.) are now skipped by default unless an idempotency header is detected.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 39657a3. 10 files reviewed, 3 issues evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added metadata-aware writes for validated record creation with support for multiple attribute types (text, select, status, currency, date, location, etc.)
  * Enhanced error handling with detailed error type detection (auth, permission, rate limit, validation)
  * Improved retry logic with support for idempotent requests and unsafe HTTP methods

* **Documentation**
  * Added guide for schema-based validated writes with code examples

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hbmartin/attio-ts-sdk/pull/157)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->