### PR TITLE
fix: Clear failed allowed-value cache entries and Parallelize write-value field and entry serialization paths

### DIFF
--- a/src/attio/write-value-serializer.ts
+++ b/src/attio/write-value-serializer.ts
@@ -37,7 +37,10 @@ const rawValueObjectSchema = z
       });
     }
   });
-const dateLikeSchema = z.union([z.string(), z.date()]);
+const validDateSchema = z
+  .date()
+  .refine((date) => !Number.isNaN(date.getTime()), "Expected a valid date.");
+const dateLikeSchema = z.union([z.string(), validDateSchema]);
 const recordReferenceInputSchema = z.object({
   targetObject: nonEmptyStringSchema,
   targetRecordId: nonEmptyStringSchema,

--- a/src/attio/write-values.ts
+++ b/src/attio/write-values.ts
@@ -150,6 +150,9 @@ const createAllowedValueGetter = ({
       attribute: attribute.api_slug,
       type: attribute.type === "status" ? "status" : "select",
       options,
+    }).catch((error: unknown) => {
+      allowedValueCache.delete(cacheKey);
+      throw error;
     });
     allowedValueCache.set(cacheKey, promise);
     return promise;
@@ -169,19 +172,19 @@ const serializeEntries = async ({
     attribute: ZodAttribute,
   ) => Promise<NormalizedAllowedValue[]>;
 }): Promise<unknown[]> => {
-  const serializedEntries: unknown[] = [];
+  const results = await Promise.all(
+    entries.map(async (entry): Promise<unknown[]> => {
+      if (entry === undefined || entry === null) {
+        return [];
+      }
 
-  for (const entry of entries) {
-    if (entry !== undefined && entry !== null) {
       try {
-        serializedEntries.push(
-          ...(await serializeAttributeEntry({
-            attribute,
-            entry,
-            options,
-            getAllowedValues,
-          })),
-        );
+        return await serializeAttributeEntry({
+          attribute,
+          entry,
+          options,
+          getAllowedValues,
+        });
       } catch (error) {
         if (error instanceof z.ZodError) {
           throw new AttioResponseError(
@@ -194,10 +197,10 @@ const serializeEntries = async ({
         }
         throw error;
       }
-    }
-  }
+    }),
+  );
 
-  return serializedEntries;
+  return results.flat();
 };
 
 const buildFieldValues = async ({
@@ -265,14 +268,19 @@ const createWriteValuesBuilder = ({
     };
     const values: SchemaWriteValues = {};
 
-    for (const [key, fieldValue] of Object.entries(input)) {
-      const result = await buildFieldValues({
-        lookup,
-        key,
-        fieldValue,
-        options: resolvedOptions,
-        getAllowedValues,
-      });
+    const results = await Promise.all(
+      Object.entries(input).map(([key, fieldValue]) =>
+        buildFieldValues({
+          lookup,
+          key,
+          fieldValue,
+          options: resolvedOptions,
+          getAllowedValues,
+        }),
+      ),
+    );
+
+    for (const result of results) {
       if (result) {
         values[result.slug] = result.values;
       }

--- a/test/attio/errors.spec.ts
+++ b/test/attio/errors.spec.ts
@@ -231,6 +231,28 @@ describe("normalizeAttioError", () => {
     expect(error.errors).toEqual([{ code: "validation_type" }]);
   });
 
+  it("extracts details from the first nested errors item", () => {
+    const response = new Response(null, { status: 400 });
+    const payload = {
+      errors: [
+        {
+          message: "First validation failed",
+          code: "validation_type",
+          type: "validation_error",
+          status_code: 422,
+        },
+      ],
+    };
+
+    const error = normalizeAttioError(payload, { response });
+
+    expect(error.message).toBe("First validation failed");
+    expect(error.code).toBe("validation_type");
+    expect(error.type).toBe("validation_error");
+    expect(error.status).toBe(400);
+    expect(error.errors).toEqual(payload.errors);
+  });
+
   it("extracts status_code from payload", () => {
     const error = normalizeAttioError({
       message: "Error",
@@ -372,6 +394,10 @@ describe("stable error helpers", () => {
   });
 
   it("extracts status from normalized and response-shaped errors", () => {
+    const responseError = new AttioApiError("conflict", { status: 422 });
+    responseError.response = new Response(null, { status: 409 });
+
+    expect(getAttioErrorStatus(responseError)).toBe(409);
     expect(
       getAttioErrorStatus(new AttioApiError("missing", { status: 404 })),
     ).toBe(404);

--- a/test/attio/retry.spec.ts
+++ b/test/attio/retry.spec.ts
@@ -154,6 +154,24 @@ describe("retry", () => {
         ),
       ).toBe(false);
     });
+
+    it("detects idempotency headers from tuple inputs and ignores empty values", () => {
+      expect(
+        hasIdempotencyHeader(
+          [["idempotency-key", "request-1"]],
+          config.idempotencyHeaderNames,
+        ),
+      ).toBe(true);
+      expect(
+        hasIdempotencyHeader(
+          [["idempotency-key", ""]],
+          config.idempotencyHeaderNames,
+        ),
+      ).toBe(false);
+      expect(
+        hasIdempotencyHeader("invalid", config.idempotencyHeaderNames),
+      ).toBe(false);
+    });
   });
 
   describe("callWithRetry", () => {
@@ -207,6 +225,22 @@ describe("retry", () => {
       const fn = vi.fn().mockRejectedValue(error);
 
       await expect(callWithRetry(fn)).rejects.toEqual(error);
+      expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not retry unsafe requests without idempotency headers", async () => {
+      const error = { status: 500 };
+      const fn = vi.fn().mockRejectedValue(error);
+
+      await expect(
+        callWithRetry(
+          fn,
+          { maxRetries: 2, initialDelayMs: 1 },
+          {
+            method: "POST",
+          },
+        ),
+      ).rejects.toEqual(error);
       expect(fn).toHaveBeenCalledTimes(1);
     });
 

--- a/test/attio/write-values.spec.ts
+++ b/test/attio/write-values.spec.ts
@@ -60,6 +60,24 @@ const allowedValues = (
     archived: entry.archived ?? false,
   }));
 
+interface DeferredAllowedValues {
+  promise: Promise<NormalizedAllowedValue[]>;
+  resolve: (value: NormalizedAllowedValue[]) => void;
+}
+
+const createDeferredAllowedValues = (): DeferredAllowedValues => {
+  let resolveDeferred: ((value: NormalizedAllowedValue[]) => void) | undefined;
+  const promise = new Promise<NormalizedAllowedValue[]>((resolve) => {
+    resolveDeferred = resolve;
+  });
+
+  if (!resolveDeferred) {
+    throw new Error("Deferred allowed values resolver was not initialized.");
+  }
+
+  return { promise, resolve: resolveDeferred };
+};
+
 describe("createWriteValuesBuilder", () => {
   it("resolves titles and slugs, then serializes native values", async () => {
     const builder = createWriteValuesBuilder({
@@ -128,6 +146,73 @@ describe("createWriteValuesBuilder", () => {
       status: [{ status: "Customer" }],
     });
     expect(allowedValueResolver).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries allowed value lookups after transient resolver failures", async () => {
+    const transientError = new Error("Metadata fetch failed");
+    const allowedValueResolver = vi
+      .fn<() => Promise<NormalizedAllowedValue[]>>()
+      .mockRejectedValueOnce(transientError)
+      .mockResolvedValue(allowedValues([{ id: "opt_1", title: "Prospect" }]));
+    const builder = createWriteValuesBuilder({
+      target: "objects",
+      identifier: "companies",
+      attributes: [
+        mockAttribute({ slug: "stage", title: "Stage", type: "select" }),
+      ],
+      allowedValueResolver,
+    });
+
+    await expect(builder.buildValues({ Stage: "Prospect" })).rejects.toThrow(
+      transientError,
+    );
+    await expect(builder.buildValues({ Stage: "Prospect" })).resolves.toEqual({
+      stage: [{ option: "Prospect" }],
+    });
+    expect(allowedValueResolver).toHaveBeenCalledTimes(2);
+  });
+
+  it("starts independent allowed value lookups before awaiting earlier fields", async () => {
+    const stageValues = createDeferredAllowedValues();
+    const statusValues = createDeferredAllowedValues();
+    const requestedAttributes: string[] = [];
+    const allowedValueResolver = vi.fn(({ attribute }) => {
+      requestedAttributes.push(attribute);
+
+      if (attribute === "stage") {
+        return stageValues.promise;
+      }
+
+      if (attribute === "status") {
+        return statusValues.promise;
+      }
+
+      return Promise.resolve([]);
+    });
+    const builder = createWriteValuesBuilder({
+      target: "objects",
+      identifier: "companies",
+      attributes: [
+        mockAttribute({ slug: "stage", title: "Stage", type: "select" }),
+        mockAttribute({ slug: "status", title: "Status", type: "status" }),
+      ],
+      allowedValueResolver,
+    });
+
+    const buildPromise = builder.buildValues({
+      Stage: "Prospect",
+      Status: "Customer",
+    });
+
+    expect(requestedAttributes).toEqual(["stage", "status"]);
+
+    stageValues.resolve(allowedValues([{ id: "opt_1", title: "Prospect" }]));
+    statusValues.resolve(allowedValues([{ id: "sta_1", title: "Customer" }]));
+
+    await expect(buildPromise).resolves.toEqual({
+      stage: [{ option: "Prospect" }],
+      status: [{ status: "Customer" }],
+    });
   });
 
   it("accepts existing value factory arrays and record reference objects", async () => {
@@ -276,6 +361,20 @@ describe("createWriteValuesBuilder", () => {
     ).rejects.toThrow(AttioResponseError);
     await expect(
       builder.buildValues({ Email: "not-an-email" }),
+    ).rejects.toMatchObject({ code: "INVALID_WRITE_VALUE" });
+  });
+
+  it("rejects invalid Date objects as invalid write values", async () => {
+    const builder = createWriteValuesBuilder({
+      target: "objects",
+      identifier: "companies",
+      attributes: [
+        mockAttribute({ slug: "founded", title: "Founded", type: "date" }),
+      ],
+    });
+
+    await expect(
+      builder.buildValues({ Founded: new Date("invalid") }),
     ).rejects.toMatchObject({ code: "INVALID_WRITE_VALUE" });
   });
 });

--- a/test/test-utils.spec.ts
+++ b/test/test-utils.spec.ts
@@ -2,6 +2,25 @@ import { describe, expect, it } from "vitest";
 
 import { restoreGlobalProperty, withGlobalProperties } from "./test-utils";
 
+class GlobalValueThenable implements PromiseLike<unknown> {
+  private readonly key: string;
+
+  constructor(key: string) {
+    this.key = key;
+  }
+
+  // biome-ignore lint/suspicious/noThenProperty: This intentionally models a non-Promise thenable.
+  then<TResult1 = unknown, TResult2 = never>(
+    onfulfilled?: ((value: unknown) => PromiseLike<TResult1> | TResult1) | null,
+    onrejected?: ((reason: unknown) => PromiseLike<TResult2> | TResult2) | null,
+  ): PromiseLike<TResult1 | TResult2> {
+    return Promise.resolve(Reflect.get(globalThis, this.key)).then(
+      onfulfilled,
+      onrejected,
+    );
+  }
+}
+
 describe("test utils", () => {
   it("restores global properties after a sync action", () => {
     const key = "__attio_sync_test_global__";
@@ -53,6 +72,60 @@ describe("test utils", () => {
       } else {
         expect(Reflect.has(globalThis, key)).toBe(false);
       }
+    } finally {
+      restoreGlobalProperty(key, originalDescriptor);
+    }
+  });
+
+  it("restores global properties after a custom thenable settles", async () => {
+    const key = "__attio_thenable_test_global__";
+    const originalDescriptor = Object.getOwnPropertyDescriptor(globalThis, key);
+
+    try {
+      const result = await withGlobalProperties(
+        { [key]: "temporary" },
+        () => new GlobalValueThenable(key),
+      );
+
+      expect(result).toBe("temporary");
+      if (originalDescriptor) {
+        expect(Object.getOwnPropertyDescriptor(globalThis, key)).toEqual(
+          originalDescriptor,
+        );
+      } else {
+        expect(Reflect.has(globalThis, key)).toBe(false);
+      }
+    } finally {
+      restoreGlobalProperty(key, originalDescriptor);
+    }
+  });
+
+  it("restores global properties when setup fails", () => {
+    const key = "__attio_setup_failure_test_global__";
+    const originalDescriptor = Object.getOwnPropertyDescriptor(globalThis, key);
+    const originalUndefinedDescriptor = Object.getOwnPropertyDescriptor(
+      globalThis,
+      "undefined",
+    );
+
+    try {
+      expect(() =>
+        withGlobalProperties(
+          { [key]: "temporary", undefined: "temporary" },
+          () => Reflect.get(globalThis, key),
+        ),
+      ).toThrow(TypeError);
+
+      if (originalDescriptor) {
+        expect(Object.getOwnPropertyDescriptor(globalThis, key)).toEqual(
+          originalDescriptor,
+        );
+      } else {
+        expect(Reflect.has(globalThis, key)).toBe(false);
+      }
+      expect(Object.getOwnPropertyDescriptor(globalThis, "undefined")).toEqual(
+        originalUndefinedDescriptor,
+      );
     } finally {
       restoreGlobalProperty(key, originalDescriptor);
     }

--- a/test/test-utils.ts
+++ b/test/test-utils.ts
@@ -39,9 +39,22 @@ const defineGlobalProperties = (properties: Record<string, unknown>): void => {
   }
 };
 
+const hasCallableThen = (value: unknown): boolean => {
+  if (value === null) {
+    return false;
+  }
+
+  const valueType = typeof value;
+  if (valueType !== "object" && valueType !== "function") {
+    return false;
+  }
+
+  return typeof Reflect.get(value, "then") === "function";
+};
+
 function withGlobalProperties<T>(
   properties: Record<string, unknown>,
-  action: () => Promise<T>,
+  action: () => PromiseLike<T>,
 ): Promise<T>;
 function withGlobalProperties<T>(
   properties: Record<string, unknown>,
@@ -49,15 +62,16 @@ function withGlobalProperties<T>(
 ): T;
 function withGlobalProperties<T>(
   properties: Record<string, unknown>,
-  action: () => T | Promise<T>,
-): T | Promise<T> {
+  action: () => T | PromiseLike<T>,
+): unknown {
   const snapshots = snapshotGlobalProperties(properties);
-  defineGlobalProperties(properties);
 
   try {
+    defineGlobalProperties(properties);
+
     const result = action();
-    if (result instanceof Promise) {
-      return result.finally(() => {
+    if (hasCallableThen(result)) {
+      return Promise.resolve(result).finally(() => {
         restoreGlobalProperties(snapshots);
       });
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved date input validation to properly reject invalid dates
  * Enhanced value lookup caching to clear failed resolution attempts

* **Performance**
  * Optimized value lookup and entry serialization processes to execute in parallel

* **Tests**
  * Expanded test coverage for allowed-value lookups, date validation, and retry behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hbmartin/attio-ts-sdk/pull/158)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix failed allowed-value cache entries and parallelize write-value serialization
> - Failed allowed-value lookups in `createAllowedValueGetter` no longer persist in the cache; the failing entry is deleted so subsequent calls re-attempt the lookup.
> - `serializeEntries` and `buildValues` now process fields and entries concurrently via `Promise.all` instead of sequentially, preserving output order via flattening.
> - Invalid `Date` objects (e.g., `new Date('invalid')`) are now rejected during write-value validation with a specific error message.
> - Test coverage added for cache eviction/retry behavior, concurrent allowed-value lookups, and invalid date rejection.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d3b0bac.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->