### PR TITLE
fix(types): overload offset pagination resolver

### DIFF
--- a/src/attio/pagination.ts
+++ b/src/attio/pagination.ts
@@ -57,6 +57,10 @@ interface OffsetItemsQueryInput extends SharedOffsetPaginationInput {
   paginate?: boolean | "stream";
 }
 
+interface OffsetItemsCollectInput extends SharedOffsetPaginationInput {
+  paginate?: boolean;
+}
+
 const createPageResultSchema = <T>(
   itemSchema: ZodType<T>,
 ): ZodType<PageResult<T>> =>
@@ -306,10 +310,22 @@ const streamOffsetItems = <T>(
     signal: input.signal,
   });
 
-const resolveOffsetItems = <T>(
+function resolveOffsetItems<T>(
+  fetchItems: OffsetItemsFetcher<T>,
+  input: SharedOffsetPaginationInput & { paginate: "stream" },
+): AsyncIterable<T>;
+function resolveOffsetItems<T>(
+  fetchItems: OffsetItemsFetcher<T>,
+  input: OffsetItemsCollectInput,
+): Promise<T[]>;
+function resolveOffsetItems<T>(
   fetchItems: OffsetItemsFetcher<T>,
   input: OffsetItemsQueryInput,
-): Promise<T[]> | AsyncIterable<T> => {
+): Promise<T[]> | AsyncIterable<T>;
+function resolveOffsetItems<T>(
+  fetchItems: OffsetItemsFetcher<T>,
+  input: OffsetItemsQueryInput,
+): Promise<T[]> | AsyncIterable<T> {
   if (input.paginate === "stream") {
     return streamOffsetItems(fetchItems, input);
   }
@@ -319,7 +335,7 @@ const resolveOffsetItems = <T>(
   }
 
   return fetchItems(input.offset, input.limit, input.signal);
-};
+}
 
 const readRuntimeOffsetPage = async <T>(
   fetchPage: OffsetPageFetcher<T>,

--- a/test/attio/pagination.spec.ts
+++ b/test/attio/pagination.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, expectTypeOf, it, vi } from "vitest";
 import { z } from "zod";
 
 import {
@@ -10,6 +10,7 @@ import {
   paginateOffsetAsync,
   parseOffsetPageResult,
   parsePageResult,
+  resolveOffsetItems,
   toOffsetPageResult,
   toPageResult,
 } from "../../src/attio/pagination";
@@ -168,6 +169,89 @@ describe("parsePageResult", () => {
     expect(parsePageResult(undefined)).toBeUndefined();
     expect(parsePageResult("string")).toBeUndefined();
     expect(parsePageResult(123)).toBeUndefined();
+  });
+});
+
+describe("resolveOffsetItems", () => {
+  interface Item {
+    id: number;
+  }
+
+  it("infers Promise for non-paginated calls", () => {
+    const fetchItems = async (): Promise<Item[]> => [];
+
+    expectTypeOf(resolveOffsetItems(fetchItems, {})).toEqualTypeOf<
+      Promise<Item[]>
+    >();
+    expectTypeOf(
+      resolveOffsetItems(fetchItems, { paginate: false }),
+    ).toEqualTypeOf<Promise<Item[]>>();
+  });
+
+  it("infers Promise for collected pagination", () => {
+    const fetchItems = async (): Promise<Item[]> => [];
+
+    expectTypeOf(
+      resolveOffsetItems(fetchItems, { paginate: true }),
+    ).toEqualTypeOf<Promise<Item[]>>();
+  });
+
+  it("infers AsyncIterable for streamed pagination", () => {
+    const fetchItems = async (): Promise<Item[]> => [];
+
+    expectTypeOf(
+      resolveOffsetItems(fetchItems, { paginate: "stream" }),
+    ).toEqualTypeOf<AsyncIterable<Item>>();
+  });
+
+  it("fetches a single page when pagination is disabled", async () => {
+    const controller = new AbortController();
+    const fetchItems = vi.fn().mockResolvedValue([{ id: 1 }]);
+
+    const result = await resolveOffsetItems(fetchItems, {
+      offset: 10,
+      limit: 25,
+      signal: controller.signal,
+    });
+
+    expect(result).toEqual([{ id: 1 }]);
+    expect(fetchItems).toHaveBeenCalledOnce();
+    expect(fetchItems).toHaveBeenCalledWith(10, 25, controller.signal);
+  });
+
+  it("collects all pages when pagination is enabled", async () => {
+    const fetchItems = vi
+      .fn()
+      .mockResolvedValueOnce([{ id: 1 }, { id: 2 }])
+      .mockResolvedValueOnce([{ id: 3 }]);
+
+    const result = await resolveOffsetItems(fetchItems, {
+      paginate: true,
+      limit: 2,
+    });
+
+    expect(result).toEqual([{ id: 1 }, { id: 2 }, { id: 3 }]);
+    expect(fetchItems).toHaveBeenNthCalledWith(1, 0, 2, undefined);
+    expect(fetchItems).toHaveBeenNthCalledWith(2, 2, 2, undefined);
+  });
+
+  it("streams pages when stream pagination is enabled", async () => {
+    const fetchItems = vi
+      .fn()
+      .mockResolvedValueOnce([{ id: 1 }, { id: 2 }])
+      .mockResolvedValueOnce([{ id: 3 }]);
+
+    const items: Item[] = [];
+    for await (const item of resolveOffsetItems(fetchItems, {
+      paginate: "stream",
+      limit: 2,
+    })) {
+      items.push(item);
+    }
+
+    expect(items).toEqual([{ id: 1 }, { id: 2 }, { id: 3 }]);
+    expect(fetchItems).toHaveBeenNthCalledWith(1, 0, 2, undefined);
+    expect(fetchItems).toHaveBeenNthCalledWith(2, 2, 2, undefined);
   });
 });
 


### PR DESCRIPTION
Add precise resolveOffsetItems overloads for promise-returning modes.

Stream mode now infers AsyncIterable directly.

Cover the resolver with runtime tests and expectTypeOf assertions.

Model: GPT-5

Reasoning: medium

Thread: 019e2364-88a7-7df2-9657-7c5a91f6f6a1

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Overload `resolveOffsetItems` to return typed `Promise<T[]>` or `AsyncIterable<T>` based on input
> - Refactors `resolveOffsetItems` in [pagination.ts](https://github.com/hbmartin/attio-ts-sdk/pull/160/files#diff-84911383733091412d75b200e1391dee4bb445fc8f0e93d1be3e8c2490573c68) from a const arrow function with a union return type to a function declaration with explicit overloads, so callers get the correct return type (`Promise<T[]>` vs `AsyncIterable<T>`) based on the `paginate` value without needing casts.
> - Adds a new `OffsetItemsCollectInput` interface extending `SharedOffsetPaginationInput` to distinguish collect mode from stream mode at the type level.
> - Adds tests in [pagination.spec.ts](https://github.com/hbmartin/attio-ts-sdk/pull/160/files#diff-789e1f636227fcc8185cba909d2256f88a0fccff6ebd1ed02bb649f4d20c2d0b) covering type inference via `expectTypeOf` and runtime behavior for non-paginated, collected, and streamed modes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ddb69c5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved type safety for pagination functionality with enhanced type definitions that better distinguish between different pagination modes (streaming, collecting, or fetching).

* **Tests**
  * Added comprehensive test coverage for pagination behavior, including type-level assertions and runtime validation across all pagination modes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hbmartin/attio-ts-sdk/pull/160)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->