### PR TITLE
fix: export offset pagination input contracts

### DIFF
--- a/src/attio/pagination.ts
+++ b/src/attio/pagination.ts
@@ -61,6 +61,10 @@ interface OffsetItemsCollectInput extends SharedOffsetPaginationInput {
   paginate?: boolean;
 }
 
+interface OffsetItemsStreamInput extends SharedOffsetPaginationInput {
+  paginate: "stream";
+}
+
 const createPageResultSchema = <T>(
   itemSchema: ZodType<T>,
 ): ZodType<PageResult<T>> =>
@@ -312,7 +316,7 @@ const streamOffsetItems = <T>(
 
 function resolveOffsetItems<T>(
   fetchItems: OffsetItemsFetcher<T>,
-  input: SharedOffsetPaginationInput & { paginate: "stream" },
+  input: OffsetItemsStreamInput,
 ): AsyncIterable<T>;
 function resolveOffsetItems<T>(
   fetchItems: OffsetItemsFetcher<T>,
@@ -481,7 +485,9 @@ async function* paginateOffsetAsync<T>(
 }
 
 export type {
+  OffsetItemsCollectInput,
   OffsetItemsQueryInput,
+  OffsetItemsStreamInput,
   OffsetPageResult,
   OffsetPaginationAsyncOptions,
   OffsetPaginationOptions,

--- a/test/attio/pagination.spec.ts
+++ b/test/attio/pagination.spec.ts
@@ -1,6 +1,11 @@
 import { describe, expect, expectTypeOf, it, vi } from "vitest";
 import { z } from "zod";
 
+import type {
+  OffsetItemsCollectInput,
+  OffsetItemsQueryInput,
+  OffsetItemsStreamInput,
+} from "../../src/attio/pagination";
 import {
   createOffsetPageResultSchema,
   createPageResultSchema,
@@ -202,6 +207,29 @@ describe("resolveOffsetItems", () => {
     expectTypeOf(
       resolveOffsetItems(fetchItems, { paginate: "stream" }),
     ).toEqualTypeOf<AsyncIterable<Item>>();
+  });
+
+  it("exposes named input types for collected and streamed pagination", () => {
+    const fetchItems = async (): Promise<Item[]> => [];
+    const collectInput: OffsetItemsCollectInput = { paginate: true, limit: 2 };
+    const defaultInput: OffsetItemsCollectInput = { limit: 2 };
+    const streamInput: OffsetItemsStreamInput = {
+      paginate: "stream",
+      limit: 2,
+    };
+
+    expectTypeOf(collectInput).toMatchTypeOf<OffsetItemsQueryInput>();
+    expectTypeOf(defaultInput).toMatchTypeOf<OffsetItemsQueryInput>();
+    expectTypeOf(streamInput).toMatchTypeOf<OffsetItemsQueryInput>();
+    expectTypeOf(resolveOffsetItems(fetchItems, collectInput)).toEqualTypeOf<
+      Promise<Item[]>
+    >();
+    expectTypeOf(resolveOffsetItems(fetchItems, defaultInput)).toEqualTypeOf<
+      Promise<Item[]>
+    >();
+    expectTypeOf(resolveOffsetItems(fetchItems, streamInput)).toEqualTypeOf<
+      AsyncIterable<Item>
+    >();
   });
 
   it("fetches a single page when pagination is disabled", async () => {


### PR DESCRIPTION
Export the collect input type and introduce a named stream input type.

Use the named stream contract in the resolveOffsetItems stream overload.

Add type-level coverage for the public collect and stream input contracts.

Model: GPT-5 Codex

Reasoning: medium

Thread: 019e2371-348e-75c3-87fc-f5948a4d5fc8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved type definitions for offset-pagination streaming requests with a dedicated interface for clearer API contracts.

* **Tests**
  * Added type-level tests to validate pagination input types and expected return types across different pagination modes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hbmartin/attio-ts-sdk/pull/162)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Export `OffsetItemsCollectInput` and `OffsetItemsStreamInput` types from pagination module
> Adds named exports for `OffsetItemsCollectInput` and `OffsetItemsStreamInput` in [pagination.ts](https://github.com/hbmartin/attio-ts-sdk/pull/162/files#diff-84911383733091412d75b200e1391dee4bb445fc8f0e93d1be3e8c2490573c68). `OffsetItemsStreamInput` is introduced as a named interface (extending `SharedOffsetPaginationInput` with `paginate: "stream"`) to replace the previously inline intersection type used in the `resolveOffsetItems` overload. A test is added to verify the exported types produce the correct return types (`Promise<Item[]>` vs `AsyncIterable<Item>`).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6821f61.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->