### PR TITLE
fix: publish dual esm cjs package

### DIFF
--- a/.attw.json
+++ b/.attw.json
@@ -1,4 +1,3 @@
 {
-  "profile": "node16",
-  "ignoreRules": ["cjs-resolves-to-esm"]
+  "profile": "node16"
 }

--- a/README.md
+++ b/README.md
@@ -1074,7 +1074,7 @@ const { data: webhooks } = await getV2Webhooks({ client });
 - **[Hey API](https://heyapi.dev/)**: OpenAPI client and Zod schema generation
 - **Biome**: lint and format with a single tool
 - **Vitest**: fast tests with coverage and thresholds
-- **tsdown**: ESM builds for Node
+- **tsdown**: dual ESM/CJS builds for Node
 - **CI**: lint, typecheck, test, coverage, and size comments/badges
 - **Deno-friendly**: `.ts` source imports for direct consumption
 - **OIDC + Provenance**: publish to npm and JSR via manual CI release

--- a/package.json
+++ b/package.json
@@ -35,11 +35,12 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/index.d.mts",
-      "import": "./dist/index.mjs"
-    }
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.cjs"
+    },
+    "./package.json": "./package.json"
   },
-  "types": "./dist/index.d.mts",
+  "types": "./dist/index.d.cts",
   "sideEffects": false,
   "files": [
     "dist"
@@ -113,5 +114,7 @@
       "**/*.yml"
     ],
     "absolute": false
-  }
+  },
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.mjs"
 }

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -2,7 +2,14 @@ import { defineConfig } from "tsdown";
 
 export default defineConfig({
   entry: { index: "./src/index.ts" },
+  format: ["esm", "cjs"],
   platform: "node",
   dts: true,
   sourcemap: true,
+  exports: true,
+  publint: true,
+  attw: {
+    profile: "node16",
+    level: "error",
+  },
 });


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Publish dual ESM/CJS package output
- Updates [tsdown.config.ts](https://github.com/hbmartin/attio-ts-sdk/pull/168/files#diff-c105f99c241d6d60e41561e663ee096629894e9b2a773c82283655b323f59485) to emit both ESM (`./dist/index.mjs`) and CJS (`./dist/index.cjs`) formats, and enables `exports`, `publint`, and `attw` checks during build.
- Updates [package.json](https://github.com/hbmartin/attio-ts-sdk/pull/168/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) exports map to include a `require` field for CJS consumers, adds a `./package.json` subpath export, and switches the top-level `types` to `./dist/index.d.cts`.
- Removes the `cjs-resolves-to-esm` ignore rule from [.attw.json](https://github.com/hbmartin/attio-ts-sdk/pull/168/files#diff-a3be4137698f4bdc5777d3831fac4e67d11c102c5e57dd54906ff333cb551aff) now that a proper CJS build exists.
- Behavioral Change: the top-level `types` entry now points to a `.d.cts` file instead of `.d.mts`, which may affect TypeScript consumers using `moduleResolution: node`.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized d24bf4a.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build configuration to generate dual ESM/CJS outputs for Node environments.
  * Updated package entry points to properly resolve both ES module and CommonJS imports.

* **Documentation**
  * Updated development tools documentation to reflect dual format build support.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hbmartin/attio-ts-sdk/pull/168)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->