### PR TITLE
fix: guard Response schema check

### DIFF
--- a/src/attio/files.ts
+++ b/src/attio/files.ts
@@ -34,7 +34,11 @@ const fileEntryWithChildrenSchema = zFile
   .or(zConnectedFolder);
 const downloadResponseSchema = z
   .object({
-    response: z.instanceof(Response).optional(),
+    response: z
+      .custom<Response>(
+        (value) => typeof Response !== "undefined" && value instanceof Response,
+      )
+      .optional(),
   })
   .passthrough();
 

--- a/test/attio/files.spec.ts
+++ b/test/attio/files.spec.ts
@@ -164,6 +164,21 @@ describe("files", () => {
       });
     });
 
+    it("accepts already-unwrapped generated list responses", async () => {
+      const file = createMockFile();
+      getFilesRequest.mockResolvedValue({
+        data: [file],
+        pagination: { next_cursor: null },
+      });
+
+      const result = await listFiles({
+        object: createFileObjectId("people"),
+        recordId: createFileRecordId(recordId),
+      });
+
+      expect(result).toEqual([file]);
+    });
+
     it("collects cursor pages when pagination is enabled", async () => {
       const file = createMockFile();
       const folder = createMockFolder();
@@ -302,6 +317,51 @@ describe("files", () => {
         parseAs: "text",
         responseStyle: "fields",
       });
+    });
+
+    it("returns blob content when requested", async () => {
+      const blob = new Blob(["hello"], { type: "text/plain" });
+      downloadFileRequest.mockResolvedValue({ data: blob });
+
+      const result = await downloadFile({
+        fileId: createFileId(fileId),
+        parseAs: "blob",
+      });
+
+      expect(result).toBe(blob);
+    });
+
+    it("returns null stream content when the runtime has no body", async () => {
+      downloadFileRequest.mockResolvedValue({ data: null });
+
+      const result = await downloadFile({
+        fileId: createFileId(fileId),
+        parseAs: "stream",
+      });
+
+      expect(result).toBeNull();
+    });
+
+    it("returns stream content when requested", async () => {
+      const stream = new ReadableStream<Uint8Array>();
+      downloadFileRequest.mockResolvedValue({ data: stream });
+
+      const result = await downloadFile({
+        fileId: createFileId(fileId),
+        parseAs: "stream",
+      });
+
+      expect(result).toBe(stream);
+    });
+
+    it("throws when downloaded content does not match parse mode", async () => {
+      downloadFileRequest.mockResolvedValue({
+        data: new Uint8Array([1, 2, 3]).buffer,
+      });
+
+      await expect(
+        downloadFile({ fileId: createFileId(fileId), parseAs: "text" }),
+      ).rejects.toThrow("Invalid file download response.");
     });
   });
 

--- a/test/attio/sdk.spec.ts
+++ b/test/attio/sdk.spec.ts
@@ -115,6 +115,7 @@ describe("createAttioSdk", () => {
     const sdk = createAttioSdk({ client });
 
     await sdk.objects.list();
+    await sdk.objects.list({});
     await sdk.objects.get({ object: "companies" });
     await sdk.objects.create({
       apiSlug: "deals",
@@ -140,6 +141,7 @@ describe("createAttioSdk", () => {
     await sdk.records.query({ object: "companies" });
 
     await sdk.lists.list();
+    await sdk.lists.list({});
     await sdk.lists.get({ list: "list_1" });
     await sdk.lists.queryEntries({ list: "list_1" });
     await sdk.lists.addEntry({ list: "list_1", parentRecordId: "rec_1" });
@@ -154,6 +156,7 @@ describe("createAttioSdk", () => {
       parentObject: noteParentObject,
       parentRecordId: noteParentRecordId,
     });
+    await sdk.notes.list();
     await sdk.notes.get({ noteId: "note_1" });
     await sdk.notes.create({
       parentObject: noteParentObject,
@@ -165,6 +168,7 @@ describe("createAttioSdk", () => {
     await sdk.notes.delete({ noteId: "note_1" });
 
     await sdk.tasks.list({ isCompleted: false });
+    await sdk.tasks.list();
     await sdk.tasks.get({ taskId: "task_1" });
     await sdk.tasks.create({
       data: {
@@ -186,11 +190,15 @@ describe("createAttioSdk", () => {
     await sdk.files.listForPerson({ personId: fileRecordId });
     await sdk.files.get({ fileId });
     await sdk.files.download({ fileId });
+    await sdk.files.download({ fileId, parseAs: "blob" });
+    await sdk.files.download({ fileId, parseAs: "stream" });
+    await sdk.files.download({ fileId, parseAs: "text" });
     await sdk.files.getDownloadUrl({ fileId });
 
     await sdk.search.records({ query: "acme", objects: ["companies"] });
 
     await sdk.workspaceMembers.list();
+    await sdk.workspaceMembers.list({});
     await sdk.workspaceMembers.get({ workspaceMemberId: "member_1" });
 
     await sdk.metadata.listAttributes({
@@ -373,6 +381,21 @@ describe("createAttioSdk", () => {
       fileId,
       parseAs: "arrayBuffer",
     });
+    expect(mocks.files.downloadFile).toHaveBeenCalledWith({
+      client,
+      fileId,
+      parseAs: "blob",
+    });
+    expect(mocks.files.downloadFile).toHaveBeenCalledWith({
+      client,
+      fileId,
+      parseAs: "stream",
+    });
+    expect(mocks.files.downloadFile).toHaveBeenCalledWith({
+      client,
+      fileId,
+      parseAs: "text",
+    });
     expect(mocks.files.getFileDownloadUrl).toHaveBeenCalledWith({
       client,
       fileId,
@@ -508,6 +531,15 @@ describe("createAttioSdk", () => {
     });
 
     expect(sdk.client.getConfig().auth).toBe("attio_test_token_12345");
+  });
+
+  it("accepts default SDK construction", () => {
+    const sdk = createAttioSdk();
+
+    expect(sdk.diagnostics.health()).toMatchObject({
+      baseUrl: "https://api.attio.com",
+      ok: true,
+    });
   });
 
   it("exposes diagnostics health and cache stats", () => {


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Fix `downloadResponseSchema` to guard against undefined global `Response`
- Replaces `z.instanceof(Response)` with a custom Zod predicate in [files.ts](https://github.com/hbmartin/attio-ts-sdk/pull/170/files#diff-cd165a4991a074e4254e8fa2c83fe97d2e083deb218dec21023cfcc74fb29f28) that checks `typeof Response !== "undefined"` before calling `instanceof`, preventing a runtime error when the global is unavailable.
- Adds tests covering `listFiles` pagination input shapes and `downloadFile` parse modes (`blob`, `stream`, `text`) in [files.spec.ts](https://github.com/hbmartin/attio-ts-sdk/pull/170/files#diff-cb535368f62302bba4f7b0f4e88a1bf598d49c27569ca6b0452a487ca64803b4).
- Extends SDK binding tests in [sdk.spec.ts](https://github.com/hbmartin/attio-ts-sdk/pull/170/files#diff-5624545b99a1d177e1ca7ed7bcdb3d10ab0b76e15534cc91e50ef0d3cd9644c0) to cover optional parameter objects and default SDK construction.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 76418bd.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved response validation reliability across different environments.

* **New Features**
  * File downloads now support multiple parsing options: blob, stream, and text formats.

* **Improvements**
  * Enhanced validation with clearer error messages when file content type doesn't match the requested format.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hbmartin/attio-ts-sdk/pull/170)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->