### PR TITLE
fix: allow null currency attribute config

### DIFF
--- a/scripts/post-generate.js
+++ b/scripts/post-generate.js
@@ -1,13 +1,78 @@
 import { readFileSync, writeFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
 // Attio's API returns null for optional fields, but the generated Zod schemas
 // use z.optional() which only accepts undefined. Replace with z.nullish()
 // to accept both null and undefined.
-const filePath = resolve(
+const generatedDir = resolve(
   dirname(fileURLToPath(import.meta.url)),
-  "../src/generated/zod.gen.ts",
+  "../src/generated",
 );
-const content = readFileSync(filePath, "utf8");
-writeFileSync(filePath, content.replaceAll("z.optional(", "z.nullish("));
+
+const replaceInBlock = ({ content, start, end, replace }) => {
+  const startIndex = content.indexOf(start);
+  if (startIndex === -1) {
+    throw new Error(`Could not find generated block start: ${start}`);
+  }
+
+  const endIndex = content.indexOf(end, startIndex);
+  if (endIndex === -1) {
+    throw new Error(`Could not find generated block end: ${end}`);
+  }
+
+  const before = content.slice(0, startIndex);
+  const block = content.slice(startIndex, endIndex);
+  const after = content.slice(endIndex);
+
+  return `${before}${replace(block)}${after}`;
+};
+
+const nullableCurrencyConfigEnums = (content) =>
+  replaceInBlock({
+    content,
+    start: "export const zAttribute = z.object({",
+    end: "export const zListView = z.object({",
+    replace: (block) =>
+      block
+        .replace(
+          /(default_currency_code: z\.enum\(\[[\s\S]*?\n {12}\]\))(?!\.(?:nullable|nullish)\(\))/,
+          "$1.nullable()",
+        )
+        .replace(
+          /(display_type: z\.enum\(\[[\s\S]*?\n {12}\]\))(?!\.(?:nullable|nullish)\(\))/,
+          "$1.nullable()",
+        ),
+  });
+
+const nullableCurrencyConfigTypes = (content) =>
+  replaceInBlock({
+    content,
+    start: "export type Attribute = {",
+    end: "export type GetV2ByTargetByIdentifierAttributesData = {",
+    replace: (block) =>
+      block
+        .replace(
+          /(default_currency_code: )([^;\n]+);/,
+          (_match, prefix, type) =>
+            type.includes("| null")
+              ? `${prefix}${type};`
+              : `${prefix}${type} | null;`,
+        )
+        .replace(/(display_type: )([^;\n]+);/, (_match, prefix, type) =>
+          type.includes("| null")
+            ? `${prefix}${type};`
+            : `${prefix}${type} | null;`,
+        ),
+  });
+
+const zodPath = resolve(generatedDir, "zod.gen.ts");
+const zodContent = readFileSync(zodPath, "utf8");
+writeFileSync(
+  zodPath,
+  nullableCurrencyConfigEnums(zodContent.replaceAll("z.optional(", "z.nullish(")),
+);
+
+const typesPath = resolve(generatedDir, "types.gen.ts");
+const typesContent = readFileSync(typesPath, "utf8");
+writeFileSync(typesPath, nullableCurrencyConfigTypes(typesContent));

--- a/src/generated/types.gen.ts
+++ b/src/generated/types.gen.ts
@@ -642,11 +642,11 @@ export type Attribute = {
             /**
              * The ISO4217 code representing the currency that values for this attribute should be stored in.
              */
-            default_currency_code: 'ARS' | 'AUD' | 'BRL' | 'BGN' | 'CAD' | 'CLP' | 'CNY' | 'COP' | 'CZK' | 'DKK' | 'EUR' | 'FJD' | 'HKD' | 'HUF' | 'ISK' | 'INR' | 'ILS' | 'JPY' | 'KES' | 'KRW' | 'MYR' | 'MXN' | 'NTD' | 'NZD' | 'NGN' | 'NOK' | 'XPF' | 'PEN' | 'PHP' | 'PLN' | 'GBP' | 'RWF' | 'SAR' | 'SGD' | 'ZAR' | 'SEK' | 'CHF' | 'THB' | 'AED' | 'UYU' | 'USD';
+            default_currency_code: 'ARS' | 'AUD' | 'BRL' | 'BGN' | 'CAD' | 'CLP' | 'CNY' | 'COP' | 'CZK' | 'DKK' | 'EUR' | 'FJD' | 'HKD' | 'HUF' | 'ISK' | 'INR' | 'ILS' | 'JPY' | 'KES' | 'KRW' | 'MYR' | 'MXN' | 'NTD' | 'NZD' | 'NGN' | 'NOK' | 'XPF' | 'PEN' | 'PHP' | 'PLN' | 'GBP' | 'RWF' | 'SAR' | 'SGD' | 'ZAR' | 'SEK' | 'CHF' | 'THB' | 'AED' | 'UYU' | 'USD' | null;
             /**
              * How the currency should be displayed across the app. "code" will display the ISO currency code e.g. "USD", "name" will display the localized currency name e.g. "British pound", "narrowSymbol" will display "$1" instead of "US$1" and "symbol" will display a localized currency symbol such as "$".
              */
-            display_type: 'code' | 'name' | 'narrowSymbol' | 'symbol';
+            display_type: 'code' | 'name' | 'narrowSymbol' | 'symbol' | null;
         };
         /**
          * Configuration available for attributes of type "record-reference".

--- a/src/generated/zod.gen.ts
+++ b/src/generated/zod.gen.ts
@@ -1674,13 +1674,13 @@ export const zAttribute = z.object({
                 'AED',
                 'UYU',
                 'USD'
-            ]),
+            ]).nullable(),
             display_type: z.enum([
                 'code',
                 'name',
                 'narrowSymbol',
                 'symbol'
-            ])
+            ]).nullable()
         }),
         record_reference: z.object({
             allowed_object_ids: z.array(z.uuid()).nullable()

--- a/test/attio/generated-response-validator.spec.ts
+++ b/test/attio/generated-response-validator.spec.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { zGetV2ByTargetByIdentifierAttributesResponse } from "../../src/generated/zod.gen";
+
+describe("generated attribute response validator", () => {
+  it("accepts null currency config fields returned by Attio", () => {
+    const result = zGetV2ByTargetByIdentifierAttributesResponse.safeParse({
+      data: [
+        {
+          id: {
+            workspace_id: "550e8400-e29b-41d4-a716-446655440000",
+            object_id: "550e8400-e29b-41d4-a716-446655440001",
+            attribute_id: "550e8400-e29b-41d4-a716-446655440002",
+          },
+          title: "Amount",
+          description: null,
+          api_slug: "amount",
+          type: "currency",
+          is_system_attribute: false,
+          is_writable: true,
+          is_required: false,
+          is_unique: false,
+          is_multiselect: false,
+          is_default_value_enabled: false,
+          is_archived: false,
+          default_value: null,
+          relationship: null,
+          created_at: "2024-01-01T00:00:00.000Z",
+          config: {
+            currency: {
+              default_currency_code: null,
+              display_type: null,
+            },
+            record_reference: {
+              allowed_object_ids: null,
+            },
+          },
+        },
+      ],
+    });
+
+    if (!result.success) {
+      throw result.error;
+    }
+
+    expect(
+      result.data.data[0]?.config.currency.default_currency_code,
+    ).toBeNull();
+    expect(result.data.data[0]?.config.currency.display_type).toBeNull();
+  });
+});


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Fix null `currency` attribute config fields in generated Zod schema and TypeScript types
- Updates [scripts/post-generate.js](https://github.com/hbmartin/attio-ts-sdk/pull/171/files#diff-5299c7ea325b7a4723bd53db8174f573cc4c346a855624bfa099dfd56bc1aaf0) to append `.nullable()` to the `default_currency_code` and `display_type` `z.enum` validators within `zAttribute`'s currency config block in `zod.gen.ts`.
- Also adds `| null` to the corresponding TypeScript types in `types.gen.ts` for those two fields.
- Adds a Vitest spec confirming the generated schema accepts `null` for both currency config fields.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized f49d0d8.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of currency configuration to properly support null values for default currency code and display type in generated responses.

* **Tests**
  * Added validation tests to verify currency attribute responses with null values are correctly processed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hbmartin/attio-ts-sdk/pull/171?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->