### PR TITLE
fix: harden post-generate currency nullability

### DIFF
--- a/scripts/post-generate.js
+++ b/scripts/post-generate.js
@@ -9,6 +9,10 @@ const generatedDir = resolve(
   dirname(fileURLToPath(import.meta.url)),
   "../src/generated",
 );
+const currencyConfigFields = ["default_currency_code", "display_type"];
+const nullUnionPattern = /(^|\|)\s*null\b/;
+const trailingWhitespacePattern = /\s*$/;
+const lastMultilineUnionMemberPattern = /\n(\s*)\|[^\n]*$/;
 
 const replaceInBlock = ({ content, start, end, replace }) => {
   const startIndex = content.indexOf(start);
@@ -28,51 +32,84 @@ const replaceInBlock = ({ content, start, end, replace }) => {
   return `${before}${replace(block)}${after}`;
 };
 
-const nullableCurrencyConfigEnums = (content) =>
+const zodEnumFieldPattern = (fieldName) =>
+  new RegExp(
+    `(${fieldName}:\\s*z\\.enum\\(\\[[\\s\\S]*?\\]\\))(?!\\.(?:nullable|nullish)\\(\\))`,
+  );
+
+const typeFieldPattern = (fieldName) =>
+  new RegExp(`(${fieldName}:\\s*)([\\s\\S]*?)(\\s*;)`);
+
+const appendNullToType = (type) => {
+  if (nullUnionPattern.test(type)) {
+    return type;
+  }
+
+  const trailingWhitespace = type.match(trailingWhitespacePattern)?.[0] ?? "";
+  const baseType = type.slice(0, type.length - trailingWhitespace.length);
+  const unionIndent = baseType.match(lastMultilineUnionMemberPattern)?.[1];
+
+  if (unionIndent === undefined) {
+    return `${baseType} | null${trailingWhitespace}`;
+  }
+
+  return `${baseType}\n${unionIndent}| null${trailingWhitespace}`;
+};
+
+export const nullableCurrencyConfigEnums = (content) =>
   replaceInBlock({
     content,
     start: "export const zAttribute = z.object({",
     end: "export const zListView = z.object({",
     replace: (block) =>
-      block
-        .replace(
-          /(default_currency_code: z\.enum\(\[[\s\S]*?\n {12}\]\))(?!\.(?:nullable|nullish)\(\))/,
-          "$1.nullable()",
-        )
-        .replace(
-          /(display_type: z\.enum\(\[[\s\S]*?\n {12}\]\))(?!\.(?:nullable|nullish)\(\))/,
-          "$1.nullable()",
-        ),
+      currencyConfigFields.reduce(
+        (updatedBlock, fieldName) =>
+          updatedBlock.replace(zodEnumFieldPattern(fieldName), "$1.nullable()"),
+        block,
+      ),
   });
 
-const nullableCurrencyConfigTypes = (content) =>
+export const nullableCurrencyConfigTypes = (content) =>
   replaceInBlock({
     content,
     start: "export type Attribute = {",
     end: "export type GetV2ByTargetByIdentifierAttributesData = {",
     replace: (block) =>
-      block
-        .replace(
-          /(default_currency_code: )([^;\n]+);/,
-          (_match, prefix, type) =>
-            type.includes("| null")
-              ? `${prefix}${type};`
-              : `${prefix}${type} | null;`,
-        )
-        .replace(/(display_type: )([^;\n]+);/, (_match, prefix, type) =>
-          type.includes("| null")
-            ? `${prefix}${type};`
-            : `${prefix}${type} | null;`,
-        ),
+      currencyConfigFields.reduce(
+        (updatedBlock, fieldName) =>
+          updatedBlock.replace(
+            typeFieldPattern(fieldName),
+            (match, prefix, type, terminator) => {
+              const nullableType = appendNullToType(type);
+              if (nullableType === type) {
+                return match;
+              }
+
+              return `${prefix}${nullableType}${terminator}`;
+            },
+          ),
+        block,
+      ),
   });
 
-const zodPath = resolve(generatedDir, "zod.gen.ts");
-const zodContent = readFileSync(zodPath, "utf8");
-writeFileSync(
-  zodPath,
-  nullableCurrencyConfigEnums(zodContent.replaceAll("z.optional(", "z.nullish(")),
-);
+export const runPostGenerate = () => {
+  const zodPath = resolve(generatedDir, "zod.gen.ts");
+  const zodContent = readFileSync(zodPath, "utf8");
+  writeFileSync(
+    zodPath,
+    nullableCurrencyConfigEnums(
+      zodContent.replaceAll("z.optional(", "z.nullish("),
+    ),
+  );
 
-const typesPath = resolve(generatedDir, "types.gen.ts");
-const typesContent = readFileSync(typesPath, "utf8");
-writeFileSync(typesPath, nullableCurrencyConfigTypes(typesContent));
+  const typesPath = resolve(generatedDir, "types.gen.ts");
+  const typesContent = readFileSync(typesPath, "utf8");
+  writeFileSync(typesPath, nullableCurrencyConfigTypes(typesContent));
+};
+
+if (
+  process.argv[1] &&
+  resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+  runPostGenerate();
+}

--- a/test/post-generate.spec.ts
+++ b/test/post-generate.spec.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import {
+  nullableCurrencyConfigEnums,
+  nullableCurrencyConfigTypes,
+} from "../scripts/post-generate.js";
+
+describe("post-generate currency config nullability", () => {
+  it("makes generated enum validators nullable without fixed indentation", () => {
+    const content = [
+      "export const zAttribute = z.object({",
+      "  config: z.object({",
+      "    currency: z.object({",
+      "      default_currency_code: z.enum([",
+      "        'USD'",
+      "      ]),",
+      "      display_type: z.enum([",
+      "        'code',",
+      "        'symbol'",
+      "      ])",
+      "    })",
+      "  })",
+      "});",
+      "export const zListView = z.object({});",
+    ].join("\n");
+
+    const result = nullableCurrencyConfigEnums(content);
+
+    expect(result).toContain(
+      [
+        "default_currency_code: z.enum([",
+        "        'USD'",
+        "      ]).nullable()",
+      ].join("\n"),
+    );
+    expect(result).toContain(
+      [
+        "display_type: z.enum([",
+        "        'code',",
+        "        'symbol'",
+        "      ]).nullable()",
+      ].join("\n"),
+    );
+  });
+
+  it("makes wrapped generated type unions nullable", () => {
+    const content = [
+      "export type Attribute = {",
+      "  config: {",
+      "    currency: {",
+      "      default_currency_code:",
+      "        | 'ARS'",
+      "        | 'USD';",
+      "      display_type:",
+      "        | 'code'",
+      "        | 'symbol';",
+      "    };",
+      "  };",
+      "};",
+      "export type GetV2ByTargetByIdentifierAttributesData = {};",
+    ].join("\n");
+
+    const result = nullableCurrencyConfigTypes(content);
+
+    expect(result).toContain(
+      [
+        "default_currency_code:",
+        "        | 'ARS'",
+        "        | 'USD'",
+        "        | null;",
+      ].join("\n"),
+    );
+    expect(result).toContain(
+      [
+        "display_type:",
+        "        | 'code'",
+        "        | 'symbol'",
+        "        | null;",
+      ].join("\n"),
+    );
+  });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Currency configuration fields now properly support null values.

* **Refactor**
  * Enhanced code generation process with reusable transformation patterns for generated type files.

* **Tests**
  * Added comprehensive test coverage to verify nullable currency configuration type and enum transformations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hbmartin/attio-ts-sdk/pull/173?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden currency nullability handling in post-generate script
> - Refactors `nullableCurrencyConfigEnums` and `nullableCurrencyConfigTypes` in [post-generate.js](https://github.com/hbmartin/attio-ts-sdk/pull/173/files#diff-5299c7ea325b7a4723bd53db8174f573cc4c346a855624bfa099dfd56bc1aaf0) to iterate over a shared `currencyConfigFields` array instead of duplicating per-field regex patterns.
> - Adds `appendNullToType` logic that avoids double-applying `| null`, preserves trailing whitespace, and aligns with multiline union indentation.
> - Wraps file I/O in a `runPostGenerate` function guarded by an ESM entrypoint check, so importing the module no longer triggers file reads/writes as a side effect.
> - Adds a Vitest suite in [post-generate.spec.ts](https://github.com/hbmartin/attio-ts-sdk/pull/173/files#diff-cc288740f1aaba3e2b0825daf61b5dd3c2821ffabb332e43080e9ed709599e5e) covering enum nullable appending and multiline union type transformation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b4879d7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->