### PR TITLE
fix: relax list entry query response validation

### DIFF
--- a/src/attio/lists.ts
+++ b/src/attio/lists.ts
@@ -61,6 +61,16 @@ const listSchema: z.ZodType<List> = z
 const zListEntryData = zPostV2ListsByListEntriesResponse.shape.data;
 type ListEntryData = z.infer<typeof zListEntryData>;
 
+const listEntryQueryResponseSchema = z
+  .object({
+    data: z.array(z.object({}).passthrough()),
+  })
+  .passthrough();
+
+const validateListEntryQueryResponse = async (
+  data: unknown,
+): Promise<unknown> => listEntryQueryResponseSchema.parseAsync(data);
+
 /**
  * Infers the entry type from an input object.
  * If `itemSchema` is provided, the type is inferred from the schema.
@@ -225,6 +235,8 @@ export function queryListEntries<T extends AttioRecordLike>(
       path: { list: input.list },
       body: { filter: query.filter, limit, offset },
       ...input.options,
+      responseValidator:
+        input.options?.responseValidator ?? validateListEntryQueryResponse,
       signal,
     });
     return unwrapAndNormalizeRecords(result, query.schema);

--- a/test/attio/lists.spec.ts
+++ b/test/attio/lists.spec.ts
@@ -1,5 +1,6 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { z } from "zod";
+import { zPostV2ListsByListEntriesQueryResponse } from "../../src/generated/zod.gen";
 
 const getListsRequest = vi.fn();
 const getListByIdRequest = vi.fn();
@@ -39,6 +40,8 @@ const LIST_ID_2 = "22222222-3333-4444-a555-666666666666";
 const ENTRY_ID_1 = "33333333-4444-4555-a666-777777777777";
 const RECORD_ID = "44444444-5555-4666-a777-888888888888";
 const MEMBER_ID = "55555555-6666-4777-a888-999999999999";
+const ATTRIBUTE_ID = "66666666-7777-4888-a999-000000000000";
+const STATUS_ID = "77777777-8888-4999-a000-111111111111";
 
 const makeList = (overrides: Record<string, unknown> = {}) => ({
   id: { workspace_id: WS_ID, list_id: LIST_ID_1 },
@@ -200,15 +203,18 @@ describe("lists", () => {
       });
 
       expect(result).toEqual(entries);
-      expect(queryEntriesRequest).toHaveBeenCalledWith({
-        client: {},
-        path: { list: "list-1" },
-        body: {
-          filter: { status: { $eq: "active" } },
-          limit: undefined,
-          offset: undefined,
-        },
-      });
+      expect(queryEntriesRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          client: {},
+          path: { list: "list-1" },
+          body: {
+            filter: { status: { $eq: "active" } },
+            limit: undefined,
+            offset: undefined,
+          },
+          responseValidator: expect.any(Function),
+        }),
+      );
     });
 
     it("accepts filters helper output", async () => {
@@ -223,15 +229,18 @@ describe("lists", () => {
         filter,
       });
 
-      expect(queryEntriesRequest).toHaveBeenCalledWith({
-        client: {},
-        path: { list: "list-1" },
-        body: {
-          filter,
-          limit: undefined,
-          offset: undefined,
-        },
-      });
+      expect(queryEntriesRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          client: {},
+          path: { list: "list-1" },
+          body: {
+            filter,
+            limit: undefined,
+            offset: undefined,
+          },
+          responseValidator: expect.any(Function),
+        }),
+      );
     });
 
     it("throws when filter shape is invalid", () => {
@@ -255,15 +264,18 @@ describe("lists", () => {
         offset: 20,
       });
 
-      expect(queryEntriesRequest).toHaveBeenCalledWith({
-        client: {},
-        path: { list: "list-1" },
-        body: {
-          filter: undefined,
-          limit: 10,
-          offset: 20,
-        },
-      });
+      expect(queryEntriesRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          client: {},
+          path: { list: "list-1" },
+          body: {
+            filter: undefined,
+            limit: 10,
+            offset: 20,
+          },
+          responseValidator: expect.any(Function),
+        }),
+      );
     });
 
     it("passes additional options", async () => {
@@ -274,16 +286,19 @@ describe("lists", () => {
         options: { headers: { "X-Custom": "value" } },
       });
 
-      expect(queryEntriesRequest).toHaveBeenCalledWith({
-        client: {},
-        path: { list: "list-1" },
-        body: {
-          filter: undefined,
-          limit: undefined,
-          offset: undefined,
-        },
-        headers: { "X-Custom": "value" },
-      });
+      expect(queryEntriesRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          client: {},
+          path: { list: "list-1" },
+          body: {
+            filter: undefined,
+            limit: undefined,
+            offset: undefined,
+          },
+          headers: { "X-Custom": "value" },
+          responseValidator: expect.any(Function),
+        }),
+      );
     });
 
     describe("with paginate: true", () => {
@@ -518,6 +533,57 @@ describe("lists", () => {
         expect(result).toEqual(entries);
       });
 
+      it("lets itemSchema narrow entries with list-backed status values", async () => {
+        const entry = makeEntry({
+          entry_values: {
+            stage: [
+              {
+                active_from: "2024-01-01T00:00:00.000Z",
+                active_until: null,
+                created_by_actor: {
+                  id: MEMBER_ID,
+                  type: "workspace-member",
+                },
+                status: {
+                  id: {
+                    workspace_id: WS_ID,
+                    list_id: LIST_ID_1,
+                    attribute_id: ATTRIBUTE_ID,
+                    status_id: STATUS_ID,
+                  },
+                  title: "Qualified",
+                  is_archived: false,
+                  celebration_enabled: false,
+                  target_time_in_status: null,
+                },
+                attribute_type: "status",
+              },
+            ],
+          },
+        });
+        const apiResponse = { data: [entry] };
+        queryEntriesRequest.mockImplementationOnce(async (options) => {
+          const responseValidator =
+            options.responseValidator ??
+            ((data: unknown) =>
+              zPostV2ListsByListEntriesQueryResponse.parseAsync(data));
+          await responseValidator(apiResponse);
+          return { data: apiResponse };
+        });
+
+        const result = await queryListEntries({
+          list: "list-1",
+          itemSchema: z.object({ parent_record_id: z.string() }),
+        });
+
+        expect(result).toEqual([{ parent_record_id: RECORD_ID }]);
+        expect(queryEntriesRequest).toHaveBeenCalledWith(
+          expect.objectContaining({
+            responseValidator: expect.any(Function),
+          }),
+        );
+      });
+
       it("throws error when entries fail schema validation", async () => {
         const invalidEntries = [{ invalid: "structure" }];
         queryEntriesRequest.mockResolvedValue({
@@ -597,6 +663,27 @@ describe("lists", () => {
         };
 
         await expect(consumeStream()).rejects.toThrow("Invalid API response");
+      });
+
+      it("preserves a caller-provided response validator", async () => {
+        const customResponseValidator = vi.fn(async (data: unknown) => data);
+        const apiResponse = { data: [] };
+        queryEntriesRequest.mockImplementationOnce(async (options) => {
+          await options.responseValidator?.(apiResponse);
+          return { data: apiResponse };
+        });
+
+        await queryListEntries({
+          list: "list-1",
+          options: { responseValidator: customResponseValidator },
+        });
+
+        expect(customResponseValidator).toHaveBeenCalledWith(apiResponse);
+        expect(queryEntriesRequest).toHaveBeenCalledWith(
+          expect.objectContaining({
+            responseValidator: customResponseValidator,
+          }),
+        );
       });
     });
   });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Implemented automatic response validation for list entries queries with configurable validators, ensuring query responses are properly parsed and validated before processing.

* **Tests**
  * Added comprehensive test coverage for list entry query validation behavior, including verification that list-backed status values are correctly filtered and custom validators are properly preserved and invoked throughout the query pipeline.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hbmartin/attio-ts-sdk/pull/174?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add default response validator to `queryListEntries` for list entry responses
> - Adds a Zod schema ([lists.ts](https://github.com/hbmartin/attio-ts-sdk/pull/174/files#diff-4c00104bbb9c82e5e85f71e65b65e39452a8ee2e3a85a34a9aa699a10eeceeb8)) that validates `queryListEntries` responses as `{ data: object[] }`, with passthrough enabled so extra fields are preserved.
> - Passes this schema as a `responseValidator` to the underlying request by default; a caller-supplied `responseValidator` takes precedence.
> - Updates tests to assert the presence of `responseValidator` in query calls and adds coverage for `itemSchema` narrowing with list-backed status values.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized acf8687.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->