### PR TITLE
fix: relax list entry mutation validation

### DIFF
--- a/scripts/contract-lint.mjs
+++ b/scripts/contract-lint.mjs
@@ -27,6 +27,12 @@ const schemaDirectUnwrapFiles = new Set([
 	"src/attio/tasks.ts",
 ]);
 
+const generatedListEntryResponseSchemas = new Set([
+	"zPostV2ListsByListEntriesResponse",
+	"zPutV2ListsByListEntriesResponse",
+	"zPatchV2ListsByListEntriesByEntryIdResponse",
+]);
+
 const failures = [];
 let optionsChecked = 0;
 let overloadGroupsChecked = 0;
@@ -202,11 +208,34 @@ function checkSchemaContracts(sourceFile) {
 	});
 }
 
+function checkListEntrySchemaContracts(sourceFile) {
+	if (sourceFile.fileName !== "src/attio/lists.ts") {
+		return;
+	}
+
+	walk(sourceFile, (node) => {
+		if (!ts.isIdentifier(node)) {
+			return;
+		}
+
+		if (!generatedListEntryResponseSchemas.has(node.text)) {
+			return;
+		}
+
+		addFailure(
+			sourceFile,
+			node,
+			"list entry wrappers must use the relaxed hand-written list entry schema instead of generated response schemas.",
+		);
+	});
+}
+
 for (const file of helperFiles) {
 	const { sourceFile } = readSource(file);
 	checkOptionsContracts(sourceFile);
 	checkOverloadContracts(sourceFile);
 	checkSchemaContracts(sourceFile);
+	checkListEntrySchemaContracts(sourceFile);
 }
 
 if (failures.length > 0) {

--- a/src/attio/lists.ts
+++ b/src/attio/lists.ts
@@ -17,7 +17,6 @@ import {
   postV2ListsByListEntries,
   postV2ListsByListEntriesQuery,
 } from "../generated";
-import { zPostV2ListsByListEntriesResponse } from "../generated/zod.gen";
 import type { AttioClientInput } from "./client";
 import type { AttioFilter } from "./filters";
 import { type BrandedId, createBrandedIdSchema } from "./ids";
@@ -58,8 +57,22 @@ const listSchema: z.ZodType<List> = z
   })
   .passthrough();
 
-const zListEntryData = zPostV2ListsByListEntriesResponse.shape.data;
-type ListEntryData = z.infer<typeof zListEntryData>;
+const listEntryDataSchema = z
+  .object({
+    id: z
+      .object({
+        workspace_id: z.string(),
+        list_id: z.string(),
+        entry_id: z.string(),
+      })
+      .passthrough(),
+    parent_record_id: z.string(),
+    parent_object: z.string(),
+    created_at: z.string(),
+    entry_values: z.record(z.string(), z.array(z.unknown())),
+  })
+  .passthrough();
+type ListEntryData = z.infer<typeof listEntryDataSchema>;
 
 const listEntryQueryResponseSchema = z
   .object({
@@ -67,9 +80,19 @@ const listEntryQueryResponseSchema = z
   })
   .passthrough();
 
+const listEntryMutationResponseSchema = z
+  .object({
+    data: listEntryDataSchema,
+  })
+  .passthrough();
+
 const validateListEntryQueryResponse = async (
   data: unknown,
 ): Promise<unknown> => listEntryQueryResponseSchema.parseAsync(data);
+
+const validateListEntryMutationResponse = async (
+  data: unknown,
+): Promise<unknown> => listEntryMutationResponseSchema.parseAsync(data);
 
 /**
  * Infers the entry type from an input object.
@@ -262,8 +285,10 @@ export const addListEntry = async (
           },
         },
         ...input.options,
+        responseValidator:
+          input.options?.responseValidator ?? validateListEntryMutationResponse,
       }),
-    { schema: zListEntryData },
+    { schema: listEntryDataSchema },
   );
 
 export const updateListEntry = async (
@@ -277,8 +302,10 @@ export const updateListEntry = async (
         path: { list: input.list, entry_id: input.entryId },
         body: { data: { entry_values: input.entryValues } },
         ...input.options,
+        responseValidator:
+          input.options?.responseValidator ?? validateListEntryMutationResponse,
       }),
-    { schema: zListEntryData },
+    { schema: listEntryDataSchema },
   );
 
 export const removeListEntry = async (input: RemoveListEntryInput) =>

--- a/test/attio/lists.spec.ts
+++ b/test/attio/lists.spec.ts
@@ -66,6 +66,32 @@ const makeEntry = (overrides: Record<string, unknown> = {}) => ({
   ...overrides,
 });
 
+const makeListBackedStatusEntryValues = () => ({
+  stage: [
+    {
+      active_from: "2024-01-01T00:00:00.000Z",
+      active_until: null,
+      created_by_actor: {
+        id: MEMBER_ID,
+        type: "workspace-member",
+      },
+      status: {
+        id: {
+          workspace_id: WS_ID,
+          list_id: LIST_ID_1,
+          attribute_id: ATTRIBUTE_ID,
+          status_id: STATUS_ID,
+        },
+        title: "Qualified",
+        is_archived: false,
+        celebration_enabled: false,
+        target_time_in_status: null,
+      },
+      attribute_type: "status",
+    },
+  ],
+});
+
 describe("lists", () => {
   let listLists: typeof import("../../src/attio/lists").listLists;
   let getList: typeof import("../../src/attio/lists").getList;
@@ -535,31 +561,7 @@ describe("lists", () => {
 
       it("lets itemSchema narrow entries with list-backed status values", async () => {
         const entry = makeEntry({
-          entry_values: {
-            stage: [
-              {
-                active_from: "2024-01-01T00:00:00.000Z",
-                active_until: null,
-                created_by_actor: {
-                  id: MEMBER_ID,
-                  type: "workspace-member",
-                },
-                status: {
-                  id: {
-                    workspace_id: WS_ID,
-                    list_id: LIST_ID_1,
-                    attribute_id: ATTRIBUTE_ID,
-                    status_id: STATUS_ID,
-                  },
-                  title: "Qualified",
-                  is_archived: false,
-                  celebration_enabled: false,
-                  target_time_in_status: null,
-                },
-                attribute_type: "status",
-              },
-            ],
-          },
+          entry_values: makeListBackedStatusEntryValues(),
         });
         const apiResponse = { data: [entry] };
         queryEntriesRequest.mockImplementationOnce(async (options) => {
@@ -710,6 +712,7 @@ describe("lists", () => {
             entry_values: {},
           },
         },
+        responseValidator: expect.any(Function),
       });
     });
 
@@ -733,7 +736,32 @@ describe("lists", () => {
             entry_values: { stage: "qualified" },
           },
         },
+        responseValidator: expect.any(Function),
       });
+    });
+
+    it("relaxes response validation for list-backed status values", async () => {
+      const entry = makeEntry({
+        entry_values: makeListBackedStatusEntryValues(),
+      });
+      const apiResponse = { data: entry };
+      addEntryRequest.mockImplementationOnce(async (options) => {
+        await options.responseValidator?.(apiResponse);
+        return { data: apiResponse };
+      });
+
+      const result = await addListEntry({
+        list: "list-1",
+        parentObject: "companies",
+        parentRecordId: RECORD_ID,
+      });
+
+      expect(result).toEqual(entry);
+      expect(addEntryRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          responseValidator: expect.any(Function),
+        }),
+      );
     });
 
     it("passes additional options", async () => {
@@ -757,7 +785,26 @@ describe("lists", () => {
           },
         },
         headers: { "X-Custom": "value" },
+        responseValidator: expect.any(Function),
       });
+    });
+
+    it("preserves a caller-provided response validator", async () => {
+      const customResponseValidator = vi.fn(async (data: unknown) => data);
+      addEntryRequest.mockResolvedValue({ data: makeEntry() });
+
+      await addListEntry({
+        list: "list-1",
+        parentObject: "companies",
+        parentRecordId: "rec-123",
+        options: { responseValidator: customResponseValidator },
+      });
+
+      expect(addEntryRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          responseValidator: customResponseValidator,
+        }),
+      );
     });
   });
 
@@ -781,7 +828,32 @@ describe("lists", () => {
             entry_values: { stage: "won" },
           },
         },
+        responseValidator: expect.any(Function),
       });
+    });
+
+    it("relaxes response validation for list-backed status values", async () => {
+      const entry = makeEntry({
+        entry_values: makeListBackedStatusEntryValues(),
+      });
+      const apiResponse = { data: entry };
+      updateEntryRequest.mockImplementationOnce(async (options) => {
+        await options.responseValidator?.(apiResponse);
+        return { data: apiResponse };
+      });
+
+      const result = await updateListEntry({
+        list: "list-1",
+        entryId: ENTRY_ID_1,
+        entryValues: { stage: "qualified" },
+      });
+
+      expect(result).toEqual(entry);
+      expect(updateEntryRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          responseValidator: expect.any(Function),
+        }),
+      );
     });
 
     it("passes additional options", async () => {
@@ -803,7 +875,26 @@ describe("lists", () => {
           },
         },
         headers: { "X-Custom": "value" },
+        responseValidator: expect.any(Function),
       });
+    });
+
+    it("preserves a caller-provided response validator", async () => {
+      const customResponseValidator = vi.fn(async (data: unknown) => data);
+      updateEntryRequest.mockResolvedValue({ data: makeEntry() });
+
+      await updateListEntry({
+        list: "list-1",
+        entryId: "entry-1",
+        entryValues: { stage: "lost" },
+        options: { responseValidator: customResponseValidator },
+      });
+
+      expect(updateEntryRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          responseValidator: customResponseValidator,
+        }),
+      );
     });
   });
 


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Replace generated list entry response schemas with hand-written relaxed schemas in `lists.ts`
- Replaces usage of generated Zod schemas (`zPostV2ListsByListEntriesResponse`, `zPutV2ListsByListEntriesResponse`) in [lists.ts](https://github.com/hbmartin/attio-ts-sdk/pull/176/files#diff-4c00104bbb9c82e5e85f71e65b65e39452a8ee2e3a85a34a9aa699a10eeceeb8) with a hand-written `listEntryDataSchema` that uses `passthrough()` to tolerate extra fields (e.g. list-backed status values).
- Adds `validateListEntryMutationResponse` as the default `responseValidator` for `addListEntry` and `updateListEntry`, while preserving any caller-supplied validator.
- Adds a lint rule in [contract-lint.mjs](https://github.com/hbmartin/attio-ts-sdk/pull/176/files#diff-29aa66ee7bb7870a2e301bf926121703b46ccb1feb311e97edb7dd5766f19dcb) that fails if the disallowed generated schemas are referenced in `src/attio/lists.ts`.
- Behavioral Change: list entry mutation responses are now validated against a looser schema; fields not explicitly declared are passed through rather than rejected.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2bc3644.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation contracts for list entry mutations to ensure responses conform to expected schemas, with improved handling for list-backed status scenarios.

* **Tests**
  * Added comprehensive test coverage for list entry operations, including validation scenarios with list-backed status values and custom response validators.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hbmartin/attio-ts-sdk/pull/176?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->