### PR TITLE
fix: update schema contract lint

### DIFF
--- a/scripts/attio-openapi-patch.ts
+++ b/scripts/attio-openapi-patch.ts
@@ -77,10 +77,13 @@ const removeRequiredProperty = (
   schema.required = required.filter((field) => field !== propertyName);
 };
 
-const typeAllowsNull = (schema: JsonObject): boolean => {
-  const type = schema.type;
-  return Array.isArray(type) && type.includes("null");
+const schemaTypeIncludes = (schema: JsonObject, typeName: string): boolean => {
+  const { type } = schema;
+  return type === typeName || (Array.isArray(type) && type.includes(typeName));
 };
+
+const typeAllowsNull = (schema: JsonObject): boolean =>
+  schemaTypeIncludes(schema, "null");
 
 const markSchemaNullable = (schema: JsonObject): void => {
   const type = schema.type;
@@ -177,7 +180,7 @@ const getResponseDataSchema = (
     `${method} ${path} response.properties`,
   );
 
-  if (data.type === "array") {
+  if (schemaTypeIncludes(data, "array")) {
     return getRequiredObject(data, "items", `${method} ${path} response.data`);
   }
 
@@ -294,7 +297,11 @@ const assertCurrencyConfigFieldsAreNullable = (spec: JsonObject): void => {
       fieldName,
       "attribute.config.currency.properties",
     );
-    if (!typeAllowsNull(fieldSchema) || !getOptionalArray(fieldSchema, "enum").includes(null)) {
+    const enumValues = getOptionalArray(fieldSchema, "enum");
+    if (
+      !typeAllowsNull(fieldSchema) ||
+      (enumValues.length > 0 && !enumValues.includes(null))
+    ) {
       throw new Error(`Expected currency config ${fieldName} to be nullable.`);
     }
   }

--- a/scripts/contract-lint.mjs
+++ b/scripts/contract-lint.mjs
@@ -27,10 +27,12 @@ const schemaDirectUnwrapFiles = new Set([
 	"src/attio/tasks.ts",
 ]);
 
-const generatedListEntryResponseSchemas = new Set([
-	"zPostV2ListsByListEntriesResponse",
-	"zPutV2ListsByListEntriesResponse",
-	"zPatchV2ListsByListEntriesByEntryIdResponse",
+const removedResponseValidatorSymbols = new Set([
+	"listEntryDataSchema",
+	"validateListEntryMutationResponse",
+	"validateListEntryQueryResponse",
+	"validateRecordDataResponse",
+	"validateRecordQueryResponse",
 ]);
 
 const failures = [];
@@ -208,24 +210,33 @@ function checkSchemaContracts(sourceFile) {
 	});
 }
 
-function checkListEntrySchemaContracts(sourceFile) {
-	if (sourceFile.fileName !== "src/attio/lists.ts") {
-		return;
-	}
-
+function checkRemovedResponseValidatorContracts(sourceFile) {
 	walk(sourceFile, (node) => {
+		if (
+			ts.isImportDeclaration(node) &&
+			ts.isStringLiteral(node.moduleSpecifier) &&
+			node.moduleSpecifier.text === "./response-validators"
+		) {
+			addFailure(
+				sourceFile,
+				node,
+				"helper wrappers must use patched generated schemas instead of local response validators.",
+			);
+			return;
+		}
+
 		if (!ts.isIdentifier(node)) {
 			return;
 		}
 
-		if (!generatedListEntryResponseSchemas.has(node.text)) {
+		if (!removedResponseValidatorSymbols.has(node.text)) {
 			return;
 		}
 
 		addFailure(
 			sourceFile,
 			node,
-			"list entry wrappers must use the relaxed hand-written list entry schema instead of generated response schemas.",
+			"helper wrappers must use patched generated schemas instead of local response validators.",
 		);
 	});
 }
@@ -235,7 +246,7 @@ for (const file of helperFiles) {
 	checkOptionsContracts(sourceFile);
 	checkOverloadContracts(sourceFile);
 	checkSchemaContracts(sourceFile);
-	checkListEntrySchemaContracts(sourceFile);
+	checkRemovedResponseValidatorContracts(sourceFile);
 }
 
 if (failures.length > 0) {

--- a/test/attio-openapi-patch.spec.ts
+++ b/test/attio-openapi-patch.spec.ts
@@ -186,7 +186,12 @@ const getSchema = (spec: JsonObject, name: string): JsonObject => {
 const getProperties = (schema: JsonObject): JsonObject =>
   objectFrom(schema.properties);
 
-const getResponseDataSchema = (
+const schemaTypeIncludes = (schema: JsonObject, typeName: string): boolean => {
+  const { type } = schema;
+  return type === typeName || (Array.isArray(type) && type.includes(typeName));
+};
+
+const getResponseDataWrapperSchema = (
   spec: JsonObject,
   method: string,
   path: string,
@@ -199,8 +204,16 @@ const getResponseDataSchema = (
   const content = objectFrom(response.content);
   const json = objectFrom(content["application/json"]);
   const responseSchema = objectFrom(json.schema);
-  const data = objectFrom(getProperties(responseSchema).data);
-  return data.type === "array" ? objectFrom(data.items) : data;
+  return objectFrom(getProperties(responseSchema).data);
+};
+
+const getResponseDataSchema = (
+  spec: JsonObject,
+  method: string,
+  path: string,
+): JsonObject => {
+  const data = getResponseDataWrapperSchema(spec, method, path);
+  return schemaTypeIncludes(data, "array") ? objectFrom(data.items) : data;
 };
 
 describe("Attio OpenAPI patch", () => {
@@ -260,6 +273,53 @@ describe("Attio OpenAPI patch", () => {
       null,
     );
     expect(objectFrom(currencyProperties.display_type).enum).toContain(null);
+  });
+
+  it("loosens nullable array response data schemas", () => {
+    const spec = makePatchSpec();
+    const dataSchema = getResponseDataSchema(
+      spec,
+      "post",
+      "/v2/lists/{list}/entries/query",
+    );
+    const dataWrapper = getResponseDataWrapperSchema(
+      spec,
+      "post",
+      "/v2/lists/{list}/entries/query",
+    );
+    dataWrapper.type = ["array", "null"];
+
+    patchAttioOpenApiSpec(spec);
+
+    const valueMap = objectFrom(getProperties(dataSchema).entry_values);
+    expect(dataSchema.required).not.toContain("entry_values");
+    expect(valueMap).toMatchObject({
+      type: ["object", "null"],
+      additionalProperties: {
+        type: "array",
+        items: {},
+      },
+    });
+  });
+
+  it("allows nullable currency fields without enum constraints", () => {
+    const spec = makePatchSpec();
+    const attributeProperties = getProperties(getSchema(spec, "attribute"));
+    const config = objectFrom(attributeProperties.config);
+    const currency = objectFrom(getProperties(config).currency);
+    const currencyProperties = getProperties(currency);
+    delete objectFrom(currencyProperties.default_currency_code).enum;
+    delete objectFrom(currencyProperties.display_type).enum;
+
+    expect(() => patchAttioOpenApiSpec(spec)).not.toThrow();
+    expect(objectFrom(currencyProperties.default_currency_code).type).toEqual([
+      "string",
+      "null",
+    ]);
+    expect(objectFrom(currencyProperties.display_type).type).toEqual([
+      "string",
+      "null",
+    ]);
   });
 
   it("fails loudly if an expected response target disappears", () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved nullable type detection in OpenAPI schemas, now handling both string and array type representations
  * Enhanced response data schema validation for array types
  * Refined currency configuration validation to properly handle nullable enum fields

* **Chores**
  * Updated contract linting to enforce stricter response validator usage patterns
  * Added new test coverage for nullable array responses and nullable currency fields

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hbmartin/attio-ts-sdk/pull/180?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix schema contract lint to handle union types and nullable currency fields
> - Adds `schemaTypeIncludes` helper in [attio-openapi-patch.ts](https://github.com/hbmartin/attio-ts-sdk/pull/180/files#diff-d60555305ea0edd8ce3e42fa32f1c409997cc746c75624e3916c2ea63341f640) so nullability and array-type checks work on both scalar and union `type` values (e.g. `["array","null"]`).
> - Updates `assertCurrencyConfigFieldsAreNullable` to accept nullable currency fields without requiring a `null` enum entry when no enum is defined.
> - Replaces the `checkListEntrySchemaContracts` linter in [contract-lint.mjs](https://github.com/hbmartin/attio-ts-sdk/pull/180/files#diff-29aa66ee7bb7870a2e301bf926121703b46ccb1feb311e97edb7dd5766f19dcb) with `checkRemovedResponseValidatorContracts`, which flags imports from `./response-validators` and usage of specific validator symbols across all helper files (not just `src/attio/lists.ts`).
> - Adds tests covering union-typed nullable array response data and enum-less nullable currency fields.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0224034.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->