### PR TITLE
chore: pin pnpm 11.1.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
-          version: 11.1.1
+          version: 11.1.3
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:

--- a/.github/workflows/openapi-sync.yml
+++ b/.github/workflows/openapi-sync.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
-          version: 11.1.1
+          version: 11.1.3
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -35,7 +35,7 @@ jobs:
 
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
-          version: 11.1.1
+          version: 11.1.3
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:

--- a/docs/upgrading-to-v2.2.1.md
+++ b/docs/upgrading-to-v2.2.1.md
@@ -24,7 +24,7 @@ pnpm add attio-ts-sdk@2.2.1 zod@^4
 ```
 
 For local development in this repository, 2.2.1 targets Node.js `>=22` and uses
-`pnpm@11.1.1`.
+`pnpm@11.1.3`.
 
 ## Migration checklist
 

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
   "resolutions": {
     "@types/node": "^22"
   },
-  "packageManager": "pnpm@11.1.1",
+  "packageManager": "pnpm@11.1.3",
   "jscpd": {
     "threshold": 0,
     "reporters": [


### PR DESCRIPTION
Model: GPT-5

Reasoning: medium

Thread: 019e4219-647e-7091-b2ef-5d8106eec97f

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pin pnpm to version 11.1.3 across CI workflows and local dev docs
> Updates pnpm from 11.1.1 to 11.1.3 in [package.json](https://github.com/hbmartin/attio-ts-sdk/pull/181/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519), all GitHub Actions workflows, and the [upgrade guide](https://github.com/hbmartin/attio-ts-sdk/pull/181/files#diff-00ca9b6359f868e48832a3408ecb068dacbd9e163355f8135ccbe0589e4b6f5e).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3cf5841.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package manager to version 11.1.3 for improved build stability and consistency across development environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hbmartin/attio-ts-sdk/pull/181?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->